### PR TITLE
feat: use tracing instead of eprintln as debug output

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,11 @@ version = "0.0.0"
 [dev-dependencies]
 monoio = {path = "../monoio", features = ["sync", "utils", "bytes", "macros"]}
 
+# Enable tracing and tracing-subscriber for print out runtime debug
+# tracing information. Add these only when you enable "debug" feature.
+# tracing = "0.1"
+# tracing-subscriber = "0.3"
+
 # For hyper examples
 hyper = {version = "0.14", features = ["http1", "client", "server", "stream"]}
 monoio-compat = {path = "../monoio-compat"}

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -7,6 +7,7 @@ use monoio::net::{TcpListener, TcpStream};
 
 #[monoio::main]
 async fn main() {
+    // tracing_subscriber::fmt().with_max_level(tracing::Level::TRACE).init();
     let listener = TcpListener::bind("127.0.0.1:50002").unwrap();
     println!("listening");
     loop {

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -27,6 +27,7 @@ bytes = {version = "1", optional = true}
 flume = {version = "0.10", optional = true}
 lazy_static = {version = "1", optional = true}
 nix = {version = "0.23", optional = true}
+tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.2"
@@ -44,6 +45,6 @@ sync = ["lazy_static", "flume"]
 # enable bind cpu set
 utils = ["nix"]
 # enable debug if you want to know what runtime does
-debug = []
+debug = ["tracing"]
 
 default = ["async-cancel", "bytes", "macros", "utils"]

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -437,7 +437,7 @@ impl AsRawFd for IoUringDriver {
 
 impl Drop for IoUringDriver {
     fn drop(&mut self) {
-        debug_eprintln!("MONOIO DEBUG[IoUringDriver]: drop");
+        tracing!("MONOIO DEBUG[IoUringDriver]: drop");
 
         // Dealloc leaked memory
         unsafe { std::ptr::drop_in_place(self.timespec) };

--- a/monoio/src/macros/debug.rs
+++ b/monoio/src/macros/debug.rs
@@ -1,9 +1,9 @@
 #[cfg(all(debug_assertions, feature = "debug"))]
-macro_rules! debug_eprintln {
-    ($( $args:expr ),*) => { eprintln!( $( $args ),* ); }
+macro_rules! tracing {
+    ($( $args:expr ),*) => { tracing::trace!( $( $args ),* ); }
 }
 
 #[cfg(not(all(debug_assertions, feature = "debug")))]
-macro_rules! debug_eprintln {
+macro_rules! tracing {
     ($( $args:expr ),*) => {};
 }

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -164,8 +164,14 @@ impl<D> Runtime<D> {
                         let _ = self.driver.submit();
                     }
 
-                    // Wait and Process CQ
+                    // Wait and Process CQ(the error is ignored for not debug mode)
+                    #[cfg(not(all(debug_assertions, feature = "debug")))]
                     let _ = self.driver.park();
+
+                    #[cfg(all(debug_assertions, feature = "debug"))]
+                    if let Err(e) = self.driver.park() {
+                        tracing!("park error: {:?}", e);
+                    }
                 }
             })
         })

--- a/monoio/src/task/harness.rs
+++ b/monoio/src/task/harness.rs
@@ -47,7 +47,7 @@ where
 {
     /// Polls the inner future.
     pub(super) fn poll(self) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: poll");
+        tracing!("MONOIO DEBUG[Harness]:: poll");
         match self.poll_inner() {
             PollFuture::Notified => {
                 // We should re-schedule the task.
@@ -86,7 +86,7 @@ where
     }
 
     pub(super) fn dealloc(self) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: dealloc");
+        tracing!("MONOIO DEBUG[Harness]:: dealloc");
 
         // Release the join waker, if there is one.
         self.trailer().waker.with_mut(drop);
@@ -103,14 +103,14 @@ where
 
     /// Read the task output into `dst`.
     pub(super) fn try_read_output(self, dst: &mut Poll<T::Output>, waker: &Waker) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: try_read_output");
+        tracing!("MONOIO DEBUG[Harness]:: try_read_output");
         if can_read_output(self.header(), self.trailer(), waker) {
             *dst = Poll::Ready(self.core().stage.take_output());
         }
     }
 
     pub(super) fn drop_join_handle_slow(self) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: drop_join_handle_slow");
+        tracing!("MONOIO DEBUG[Harness]:: drop_join_handle_slow");
 
         let mut maybe_panic = None;
 
@@ -147,14 +147,14 @@ where
     /// The caller does not need to hold a ref-count besides the one that was
     /// passed to this call.
     pub(super) fn wake_by_val(self) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: wake_by_val");
+        tracing!("MONOIO DEBUG[Harness]:: wake_by_val");
         #[cfg(feature = "sync")]
         {
             use crate::utils::thread_id::get_current_thread_id;
             let (current_id, raw_id) = (get_current_thread_id(), self.header().owner_id);
 
             if current_id != raw_id {
-                debug_eprintln!("MONOIO DEBUG[Harness]:: wake_by_val with another thread id");
+                tracing!("MONOIO DEBUG[Harness]:: wake_by_val with another thread id");
                 // # Ref Count: self -> waker
                 use crate::task::waker::raw_waker;
                 let raw_waker = raw_waker::<T, S>(self.cell.cast::<Header>().as_ptr());
@@ -185,14 +185,14 @@ where
     /// caller should hold a ref-count.  This will create a new Notified and
     /// submit it if necessary.
     pub(super) fn wake_by_ref(&self) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: wake_by_ref");
+        tracing!("MONOIO DEBUG[Harness]:: wake_by_ref");
         #[cfg(feature = "sync")]
         {
             use crate::utils::thread_id::get_current_thread_id;
             let (current_id, raw_id) = (get_current_thread_id(), self.header().owner_id);
 
             if current_id != raw_id {
-                debug_eprintln!("MONOIO DEBUG[Harness]:: wake_by_ref with another thread id");
+                tracing!("MONOIO DEBUG[Harness]:: wake_by_ref with another thread id");
                 use crate::task::waker::raw_waker;
                 let waker = raw_waker::<T, S>(self.cell.cast::<Header>().as_ptr());
 
@@ -220,7 +220,7 @@ where
     }
 
     pub(super) fn drop_reference(self) {
-        debug_eprintln!("MONOIO DEBUG[Harness]:: drop_reference");
+        tracing!("MONOIO DEBUG[Harness]:: drop_reference");
         if self.header().state.ref_dec() {
             self.dealloc();
         }

--- a/monoio/src/task/state.rs
+++ b/monoio/src/task/state.rs
@@ -143,7 +143,7 @@ impl State {
     pub(super) fn drop_join_handle_fast(&self) -> Result<(), ()> {
         if *self.load() == INITIAL_STATE {
             self.store(Snapshot((INITIAL_STATE - REF_ONE) & !JOIN_INTEREST));
-            debug_eprintln!("MONOIO DEBUG[State]: drop_join_handle_fast");
+            tracing!("MONOIO DEBUG[State]: drop_join_handle_fast");
             Ok(())
         } else {
             Err(())
@@ -217,7 +217,7 @@ impl State {
         val.add(REF_ONE);
         self.store(val);
 
-        debug_eprintln!(
+        tracing!(
             "MONOIO DEBUG[State]: ref_inc {}, ptr: {:p}",
             val.ref_count(),
             self
@@ -239,7 +239,7 @@ impl State {
         // New state
         val.sub(REF_ONE);
         self.store(val);
-        debug_eprintln!(
+        tracing!(
             "MONOIO DEBUG[State]: ref_dec {}, ptr: {:p}",
             val.ref_count(),
             self

--- a/monoio/src/task/waker.rs
+++ b/monoio/src/task/waker.rs
@@ -52,7 +52,7 @@ where
     S: Schedule,
 {
     let header = ptr as *const Header;
-    debug_eprintln!("MONOIO DEBUG[Waker]: clone_waker");
+    tracing!("MONOIO DEBUG[Waker]: clone_waker");
     (*header).state.ref_inc();
     raw_waker::<T, S>(header)
 }


### PR DESCRIPTION
The internal operating status of Runtime should be observable. Enable `debug` feature and the tracing log will be printed out.

This may also solved #25 since the error information will be visible when it `park` failed. I think #25 maybe caused by `enter` failure and infinitly loop retry.