### PR TITLE
refactor: change IoBuf and IoBufMut pointer semantics and implement them for [u8; N], Box<[u8; N]>, &'static [u8; N]

### DIFF
--- a/monoio-compat/src/tcp.rs
+++ b/monoio-compat/src/tcp.rs
@@ -13,7 +13,7 @@ struct LimitedBuffer {
 }
 
 unsafe impl IoBuf for LimitedBuffer {
-    fn stable_ptr(&self) -> *const u8 {
+    fn read_ptr(&self) -> *const u8 {
         self.buf.as_ptr()
     }
 
@@ -23,7 +23,7 @@ unsafe impl IoBuf for LimitedBuffer {
 }
 
 unsafe impl IoBufMut for LimitedBuffer {
-    fn stable_mut_ptr(&mut self) -> *mut u8 {
+    fn write_ptr(&mut self) -> *mut u8 {
         self.buf.as_mut_ptr()
     }
 

--- a/monoio/src/buf/mod.rs
+++ b/monoio/src/buf/mod.rs
@@ -21,5 +21,5 @@ pub use shared_buf::{Shared, SharedBuf};
 pub(crate) fn deref(buf: &impl IoBuf) -> &[u8] {
     // Safety: the `IoBuf` trait is marked as unsafe and is expected to be
     // implemented correctly.
-    unsafe { std::slice::from_raw_parts(buf.stable_ptr(), buf.bytes_init()) }
+    unsafe { std::slice::from_raw_parts(buf.read_ptr(), buf.bytes_init()) }
 }

--- a/monoio/src/buf/slice.rs
+++ b/monoio/src/buf/slice.rs
@@ -156,7 +156,7 @@ impl<T: IoBuf> ops::Deref for SliceMut<T> {
 
 unsafe impl<T: IoBuf> IoBuf for SliceMut<T> {
     #[inline]
-    fn stable_ptr(&self) -> *const u8 {
+    fn read_ptr(&self) -> *const u8 {
         super::deref(&self.buf)[self.begin..].as_ptr()
     }
 
@@ -168,8 +168,8 @@ unsafe impl<T: IoBuf> IoBuf for SliceMut<T> {
 
 unsafe impl<T: IoBufMut> IoBufMut for SliceMut<T> {
     #[inline]
-    fn stable_mut_ptr(&mut self) -> *mut u8 {
-        unsafe { self.buf.stable_mut_ptr().add(self.begin) }
+    fn write_ptr(&mut self) -> *mut u8 {
+        unsafe { self.buf.write_ptr().add(self.begin) }
     }
 
     #[inline]
@@ -244,8 +244,8 @@ impl<T> Slice<T> {
 
 unsafe impl<T: IoBuf> IoBuf for Slice<T> {
     #[inline]
-    fn stable_ptr(&self) -> *const u8 {
-        unsafe { self.buf.stable_ptr().add(self.begin) }
+    fn read_ptr(&self) -> *const u8 {
+        unsafe { self.buf.read_ptr().add(self.begin) }
     }
 
     #[inline]

--- a/monoio/src/driver/read.rs
+++ b/monoio/src/driver/read.rs
@@ -26,7 +26,7 @@ impl<T: IoBufMut> Op<Read<T>> {
             |read| {
                 opcode::Read::new(
                     types::Fd(fd.raw_fd()),
-                    read.buf.stable_mut_ptr(),
+                    read.buf.write_ptr(),
                     read.buf.bytes_total() as _,
                 )
                 .offset(offset as _)

--- a/monoio/src/driver/recv.rs
+++ b/monoio/src/driver/recv.rs
@@ -26,7 +26,7 @@ impl<T: IoBufMut> Op<Recv<T>> {
             |recv| {
                 opcode::Recv::new(
                     types::Fd(fd.raw_fd()),
-                    recv.buf.stable_mut_ptr(),
+                    recv.buf.write_ptr(),
                     recv.buf.bytes_total() as _,
                 )
                 .build()

--- a/monoio/src/driver/send.rs
+++ b/monoio/src/driver/send.rs
@@ -33,7 +33,7 @@ impl<T: IoBuf> Op<Send<T>> {
             |send| {
                 opcode::Send::new(
                     types::Fd(fd.raw_fd()),
-                    send.buf.stable_ptr(),
+                    send.buf.read_ptr(),
                     send.buf.bytes_init() as _,
                 )
                 .flags(FLAGS)

--- a/monoio/src/driver/write.rs
+++ b/monoio/src/driver/write.rs
@@ -25,7 +25,7 @@ impl<T: IoBuf> Op<Write<T>> {
             |write| {
                 opcode::Write::new(
                     types::Fd(fd.raw_fd()),
-                    write.buf.stable_ptr(),
+                    write.buf.read_ptr(),
                     write.buf.bytes_init() as _,
                 )
                 .offset(offset as _)


### PR DESCRIPTION
Since we `Box::pin` the Op, we can guarantee IoBuf and IoBufMut will not be moved. So the semantics should be changed, and IoBuf/IoBufMut can be implemented for structs on stack.