### PR TITLE
fix: remove libc::EFD_NONBLOCK from eventfd flags

### DIFF
--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -104,7 +104,7 @@ impl IoUringDriver {
 
         // Create eventfd and register it to the ring.
         let waker = {
-            let fd = crate::syscall!(eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK))?;
+            let fd = crate::syscall!(eventfd(0, libc::EFD_CLOEXEC))?;
             unsafe {
                 use std::os::unix::io::FromRawFd;
                 std::fs::File::from_raw_fd(fd)


### PR DESCRIPTION
related issue: https://github.com/bytedance/monoio/issues/25
相关的 issue: https://github.com/bytedance/monoio/issues/25

`libc::EFD_NONBLOCK` will make fd's readOP be "ready" in io_uring at any time. It's going to become a CQE object when the kernel tries to consume it even if fd can't be read (`WOULD_BLOCK`).

fd 上若有 `libc::EFD_NONBLOCK` flag，会使 fd 上的 readOP 随时处于 "ready" 状态；当内核消费到这个 SQE 时，会发现这个 fd ：
1. 有数据可读，正常构造 CQE 对象并放入 CQ 中；
2. 没有数据可读，构造包含 WOULD_BLOCK CQE 对象，并放入 CQ 中；
这可能导致 monoio 频繁被唤醒[1]，并在调用 `IoUringDriver::inner_park` 中通过 `IoUringDriver::install_eventfd` 重新注册 `eventfd` ReadOP 到 SQ，最终导致极高 CPU 占用。

[1]: https://github.com/bytedance/monoio/blob/master/monoio/src/runtime.rs#L138-L178


<img width="1334" alt="CleanShot 2022-08-22 at 12 32 21@2x" src="https://user-images.githubusercontent.com/36234175/185840649-d0d1af36-3dca-4c31-9ce5-56643890c00a.png">
