### PR TITLE
feat: make `split/into_split` generic

### DIFF
--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,7 +1,7 @@
 //! An example TCP proxy.
 
 use monoio::{
-    io::{AsyncReadRent, AsyncWriteRent, AsyncWriteRentExt},
+    io::{AsyncReadRent, AsyncWriteRent, AsyncWriteRentExt, Splitable},
     net::{TcpListener, TcpStream},
 };
 

--- a/monoio/src/io/mod.rs
+++ b/monoio/src/io/mod.rs
@@ -22,4 +22,7 @@ pub use async_write_rent_ext::AsyncWriteRentExt;
 mod util;
 #[cfg(all(target_os = "linux", feature = "splice"))]
 pub use util::zero_copy;
-pub use util::{copy, BufReader, BufWriter, PrefixedReadIo};
+pub use util::{
+    copy, BufReader, BufWriter, OwnedReadHalf, OwnedWriteHalf, PrefixedReadIo, ReadHalf, Split,
+    Splited, WriteHalf,
+};

--- a/monoio/src/io/mod.rs
+++ b/monoio/src/io/mod.rs
@@ -24,5 +24,5 @@ mod util;
 pub use util::zero_copy;
 pub use util::{
     copy, BufReader, BufWriter, OwnedReadHalf, OwnedWriteHalf, PrefixedReadIo, ReadHalf, Split,
-    Splited, WriteHalf,
+    Splitable, WriteHalf,
 };

--- a/monoio/src/io/util/mod.rs
+++ b/monoio/src/io/util/mod.rs
@@ -12,4 +12,4 @@ pub use copy::copy;
 #[cfg(all(target_os = "linux", feature = "splice"))]
 pub use copy::zero_copy;
 pub use prefixed_io::PrefixedReadIo;
-pub use split::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Split, WriteHalf, Splitable};
+pub use split::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Split, Splitable, WriteHalf};

--- a/monoio/src/io/util/mod.rs
+++ b/monoio/src/io/util/mod.rs
@@ -12,4 +12,4 @@ pub use copy::copy;
 #[cfg(all(target_os = "linux", feature = "splice"))]
 pub use copy::zero_copy;
 pub use prefixed_io::PrefixedReadIo;
-pub use split::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Split, WriteHalf, _Split as Splited};
+pub use split::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Split, WriteHalf, Splitable};

--- a/monoio/src/io/util/mod.rs
+++ b/monoio/src/io/util/mod.rs
@@ -4,6 +4,7 @@ mod buf_reader;
 mod buf_writer;
 mod copy;
 mod prefixed_io;
+mod split;
 
 pub use buf_reader::BufReader;
 pub use buf_writer::BufWriter;
@@ -11,3 +12,4 @@ pub use copy::copy;
 #[cfg(all(target_os = "linux", feature = "splice"))]
 pub use copy::zero_copy;
 pub use prefixed_io::PrefixedReadIo;
+pub use split::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Split, WriteHalf, _Split as Splited};

--- a/monoio/src/io/util/prefixed_io.rs
+++ b/monoio/src/io/util/prefixed_io.rs
@@ -117,4 +117,4 @@ impl<I: AsyncWriteRent, P> AsyncWriteRent for PrefixedReadIo<I, P> {
 
 /// implement unsafe Split for PrefixedReadIo, it's `safe`
 /// because read/write are independent, we can safely split them into two I/O parts.
-unsafe impl<I, P> Split for PrefixedReadIo<I, P> where I: AsyncReadRent + AsyncWriteRent + Split {}
+unsafe impl<I, P> Split for PrefixedReadIo<I, P> where I: Split {}

--- a/monoio/src/io/util/prefixed_io.rs
+++ b/monoio/src/io/util/prefixed_io.rs
@@ -1,3 +1,4 @@
+use super::split::Split;
 use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut, IoVecWrapperMut},
     io::{AsyncReadRent, AsyncWriteRent},
@@ -113,3 +114,7 @@ impl<I: AsyncWriteRent, P> AsyncWriteRent for PrefixedReadIo<I, P> {
         self.io.shutdown()
     }
 }
+
+/// implement unsafe Split for PrefixedReadIo, it's `safe`
+/// because read/write are independent, we can safely split them into two I/O parts.
+unsafe impl<I, P> Split for PrefixedReadIo<I, P> where I: AsyncReadRent + AsyncWriteRent {}

--- a/monoio/src/io/util/prefixed_io.rs
+++ b/monoio/src/io/util/prefixed_io.rs
@@ -117,4 +117,4 @@ impl<I: AsyncWriteRent, P> AsyncWriteRent for PrefixedReadIo<I, P> {
 
 /// implement unsafe Split for PrefixedReadIo, it's `safe`
 /// because read/write are independent, we can safely split them into two I/O parts.
-unsafe impl<I, P> Split for PrefixedReadIo<I, P> where I: AsyncReadRent + AsyncWriteRent {}
+unsafe impl<I, P> Split for PrefixedReadIo<I, P> where I: AsyncReadRent + AsyncWriteRent + Split {}

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -28,7 +28,7 @@ pub struct ReadHalf<'cx, T>(pub &'cx T);
 /// to read/write object in both form of `Owned` or `Borrowed`.
 ///
 /// # Safety
-/// 
+///
 /// monoio cannot guarantee whether the custom object can be
 /// safely split to divided objects. Users should ensure the read
 /// operations are indenpendence from the write ones, the methods
@@ -150,7 +150,7 @@ where
 
 impl<T> OwnedReadHalf<T>
 where
-    T: AsyncWriteRent
+    T: AsyncWriteRent,
 {
     /// reunite write half
     pub fn reunite(self, other: OwnedWriteHalf<T>) -> Result<T, ReuniteError<T>> {

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -28,9 +28,11 @@ pub struct ReadHalf<'cx, T>(pub &'cx T);
 /// to read/write object in both form of `Owned` or `Borrowed`.
 ///
 /// # Safety
+/// 
 /// monoio cannot guarantee whether the custom object can be
-/// safely split to divided objects. Users should ensure the safety
-/// by themselves.
+/// safely split to divided objects. Users should ensure the read
+/// operations are indenpendence from the write ones, the methods
+/// from `AsyncReadRent` and `AsyncWriteRent` can execute concurrently.
 pub unsafe trait Split {}
 
 /// Inner split trait

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -1,0 +1,61 @@
+use std::{cell::UnsafeCell, rc::Rc};
+
+use crate::io::{AsyncReadRent, AsyncWriteRent};
+
+pub struct OwnedReadHalf<T>(Rc<UnsafeCell<T>>);
+pub struct OwnedWriteHalf<T>(Rc<UnsafeCell<T>>);
+pub struct WriteHalf<'cx, T>(&'cx T);
+pub struct ReadHalf<'cx, T>(&'cx T);
+
+/// This is a dummy unsafe trait to inform monoio,
+/// the object with has this `Split` trait can be safely split
+/// to read/write object in both form of `Owned` or `Borrowed`.
+/// Note: monoio cannot guarantee whether the custom object can be
+/// safely aplit to divided objects. Users should ensure the safety
+/// by themselves.
+pub unsafe trait Split {}
+
+/// Inner split trait
+pub trait _Split {
+    /// Owned Read Split
+    type OwnedRead;
+    /// Owned Write Split
+    type OwnedWrite;
+
+    /// Borrowed Read Split
+    type Read<'cx>
+    where
+        Self: 'cx;
+    /// Borrowed Write Split
+    type Write<'cx>
+    where
+        Self: 'cx;
+
+    /// Split into owned parts
+    fn into_split(self) -> (Self::OwnedRead, Self::OwnedWrite);
+
+    /// Split into borrowed parts
+    fn split(&self) -> (Self::Read<'_>, Self::Write<'_>);
+}
+
+impl<T> _Split for T
+where
+    T: Split + AsyncReadRent + AsyncWriteRent,
+{
+    type Read<'cx> = ReadHalf<'cx, T> where Self: 'cx;
+
+    type Write<'cx> = WriteHalf<'cx, T> where Self: 'cx;
+
+    type OwnedRead = OwnedReadHalf<T>;
+
+    type OwnedWrite = OwnedWriteHalf<T>;
+
+    fn into_split(self) -> (Self::OwnedRead, Self::OwnedWrite) {
+        let shared = Rc::new(UnsafeCell::new(self));
+        (OwnedReadHalf(shared.clone()), OwnedWriteHalf(shared))
+    }
+
+    fn split(&self) -> (Self::Read<'_>, Self::Write<'_>) {
+        (ReadHalf(&*self), WriteHalf(&*self))
+    }
+}

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -6,14 +6,16 @@ use std::{
     rc::Rc,
 };
 
-use crate::{io::{AsyncReadRent, AsyncWriteRent}};
+use crate::io::{AsyncReadRent, AsyncWriteRent};
 
 /// Owned Read Half Part
 #[derive(Debug)]
 pub struct OwnedReadHalf<T>(pub Rc<UnsafeCell<T>>);
 /// Owned Write Half Part
 #[derive(Debug)]
-pub struct OwnedWriteHalf<T>(pub Rc<UnsafeCell<T>>) where T: AsyncWriteRent;
+pub struct OwnedWriteHalf<T>(pub Rc<UnsafeCell<T>>)
+where
+    T: AsyncWriteRent;
 /// Borrowed Write Half Part
 #[derive(Debug)]
 pub struct WriteHalf<'cx, T>(pub &'cx T);
@@ -24,7 +26,7 @@ pub struct ReadHalf<'cx, T>(pub &'cx T);
 /// This is a dummy unsafe trait to inform monoio,
 /// the object with has this `Split` trait can be safely split
 /// to read/write object in both form of `Owned` or `Borrowed`.
-/// 
+///
 /// # Safety
 /// monoio cannot guarantee whether the custom object can be
 /// safely split to divided objects. Users should ensure the safety
@@ -143,7 +145,6 @@ where
         stream.shutdown()
     }
 }
-
 
 impl<T> OwnedReadHalf<T>
 where

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -6,20 +6,20 @@ use std::{
     rc::Rc,
 };
 
-use crate::io::{AsyncReadRent, AsyncWriteRent};
+use crate::io::{AsyncReadRent, AsyncWriteRent, stream::Stream};
 
 /// Owned Read Half Part
 #[derive(Debug)]
-pub struct OwnedReadHalf<T>(Rc<UnsafeCell<T>>);
+pub struct OwnedReadHalf<T>(pub Rc<UnsafeCell<T>>);
 /// Owned Write Half Part
 #[derive(Debug)]
-pub struct OwnedWriteHalf<T>(Rc<UnsafeCell<T>>);
+pub struct OwnedWriteHalf<T>(pub Rc<UnsafeCell<T>>);
 /// Borrowed Write Half Part
 #[derive(Debug)]
-pub struct WriteHalf<'cx, T>(&'cx T);
+pub struct WriteHalf<'cx, T>(pub &'cx T);
 /// Borrowed Read Half Part
 #[derive(Debug)]
-pub struct ReadHalf<'cx, T>(&'cx T);
+pub struct ReadHalf<'cx, T>(pub &'cx T);
 
 /// This is a dummy unsafe trait to inform monoio,
 /// the object with has this `Split` trait can be safely split

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -150,7 +150,7 @@ where
 
 impl<T> OwnedReadHalf<T>
 where
-    T: AsyncWriteRent + Debug,
+    T: AsyncWriteRent
 {
     /// reunite write half
     pub fn reunite(self, other: OwnedWriteHalf<T>) -> Result<T, ReuniteError<T>> {
@@ -160,7 +160,7 @@ where
 
 impl<T> OwnedWriteHalf<T>
 where
-    T: AsyncWriteRent + Debug,
+    T: AsyncWriteRent,
 {
     /// reunite read half
     pub fn reunite(self, other: OwnedReadHalf<T>) -> Result<T, ReuniteError<T>> {
@@ -180,7 +180,7 @@ where
     }
 }
 
-pub(crate) fn reunite<T: AsyncWriteRent + Debug>(
+pub(crate) fn reunite<T: AsyncWriteRent>(
     read: OwnedReadHalf<T>,
     write: OwnedWriteHalf<T>,
 ) -> Result<T, ReuniteError<T>> {
@@ -203,7 +203,7 @@ pub struct ReuniteError<T: AsyncWriteRent>(pub OwnedReadHalf<T>, pub OwnedWriteH
 
 impl<T> fmt::Display for ReuniteError<T>
 where
-    T: AsyncWriteRent + Debug,
+    T: AsyncWriteRent,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "tried to reunite halves")

--- a/monoio/src/net/tcp/mod.rs
+++ b/monoio/src/net/tcp/mod.rs
@@ -6,7 +6,5 @@ mod split;
 mod stream;
 
 pub use listener::TcpListener;
-pub use split::{
-    ReuniteError as TcpReuniteError, TcpOwnedReadHalf, TcpOwnedWriteHalf, TcpReadHalf, TcpWriteHalf,
-};
+pub use split::{TcpOwnedReadHalf, TcpOwnedWriteHalf, TcpReadHalf, TcpWriteHalf};
 pub use stream::TcpStream;

--- a/monoio/src/net/tcp/mod.rs
+++ b/monoio/src/net/tcp/mod.rs
@@ -7,7 +7,6 @@ mod stream;
 
 pub use listener::TcpListener;
 pub use split::{
-    TcpOwnedReadHalf, TcpOwnedWriteHalf,
-    TcpReadHalf, ReuniteError as TcpReuniteError, TcpWriteHalf,
+    ReuniteError as TcpReuniteError, TcpOwnedReadHalf, TcpOwnedWriteHalf, TcpReadHalf, TcpWriteHalf,
 };
 pub use stream::TcpStream;

--- a/monoio/src/net/tcp/mod.rs
+++ b/monoio/src/net/tcp/mod.rs
@@ -7,7 +7,7 @@ mod stream;
 
 pub use listener::TcpListener;
 pub use split::{
-    OwnedReadHalf as TcpOwnedReadHalf, OwnedWriteHalf as TcpOwnedWriteHalf,
-    ReadHalf as TcpReadHalf, ReuniteError as TcpReuniteError, WriteHalf as TcpWriteHalf,
+    TcpOwnedReadHalf, TcpOwnedWriteHalf,
+    TcpReadHalf, ReuniteError as TcpReuniteError, TcpWriteHalf,
 };
 pub use stream::TcpStream;

--- a/monoio/src/net/tcp/split.rs
+++ b/monoio/src/net/tcp/split.rs
@@ -1,12 +1,9 @@
-use std::{future::Future, io, net::SocketAddr};
+use std::{io, net::SocketAddr};
 
 use super::TcpStream;
-use crate::{
-    buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
-    io::{
-        as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
-        AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
-    },
+use crate::io::{
+    as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
+    OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
 };
 
 /// ReadHalf.
@@ -22,25 +19,25 @@ impl<'t> AsReadFd for TcpReadHalf<'t> {
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsyncReadRent for TcpReadHalf<'t> {
-    type ReadFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoBufMut + 'a;
-    type ReadvFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoVecBufMut + 'a,;
+// #[allow(clippy::cast_ref_to_mut)]
+// impl<'t> AsyncReadRent for TcpReadHalf<'t> {
+//     type ReadFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
+//         't: 'a, B: IoBufMut + 'a;
+//     type ReadvFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
+//         't: 'a, B: IoVecBufMut + 'a,;
 
-    fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
-        // Submit the read operation
-        let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
-        raw_stream.read(buf)
-    }
+//     fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
+//         // Submit the read operation
+//         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
+//         raw_stream.read(buf)
+//     }
 
-    fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
-        // Submit the read operation
-        let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
-        raw_stream.readv(buf)
-    }
-}
+//     fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
+//         // Submit the read operation
+//         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
+//         raw_stream.readv(buf)
+//     }
+// }
 
 #[allow(clippy::cast_ref_to_mut)]
 impl<'t> AsWriteFd for TcpWriteHalf<'t> {
@@ -50,38 +47,38 @@ impl<'t> AsWriteFd for TcpWriteHalf<'t> {
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsyncWriteRent for TcpWriteHalf<'t> {
-    type WriteFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoBuf + 'a;
-    type WritevFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoVecBuf + 'a;
-    type FlushFuture<'a> = impl Future<Output = io::Result<()>> where
-        't: 'a;
-    type ShutdownFuture<'a> = impl Future<Output = io::Result<()>> where
-        't: 'a;
+// #[allow(clippy::cast_ref_to_mut)]
+// impl<'t> AsyncWriteRent for TcpWriteHalf<'t> {
+//     type WriteFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
+//         't: 'a, B: IoBuf + 'a;
+//     type WritevFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
+//         't: 'a, B: IoVecBuf + 'a;
+//     type FlushFuture<'a> = impl Future<Output = io::Result<()>> where
+//         't: 'a;
+//     type ShutdownFuture<'a> = impl Future<Output = io::Result<()>> where
+//         't: 'a;
 
-    fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
-        // Submit the write operation
-        let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
-        raw_stream.write(buf)
-    }
+//     fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
+//         // Submit the write operation
+//         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
+//         raw_stream.write(buf)
+//     }
 
-    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> Self::WritevFuture<'_, T> {
-        let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
-        raw_stream.writev(buf_vec)
-    }
+//     fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> Self::WritevFuture<'_, T> {
+//         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
+//         raw_stream.writev(buf_vec)
+//     }
 
-    fn flush(&mut self) -> Self::FlushFuture<'_> {
-        // Tcp stream does not need flush.
-        async move { Ok(()) }
-    }
+//     fn flush(&mut self) -> Self::FlushFuture<'_> {
+//         // Tcp stream does not need flush.
+//         async move { Ok(()) }
+//     }
 
-    fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
-        let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
-        raw_stream.shutdown()
-    }
-}
+//     fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
+//         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
+//         raw_stream.shutdown()
+//     }
+// }
 
 /// OwnedReadHalf.
 pub type TcpOwnedReadHalf = OwnedReadHalf<TcpStream>;

--- a/monoio/src/net/tcp/split.rs
+++ b/monoio/src/net/tcp/split.rs
@@ -1,18 +1,12 @@
-use std::{
-    fmt::{self},
-    future::Future,
-    io,
-    net::SocketAddr,
-};
+use std::{future::Future, io, net::SocketAddr};
 
 use super::TcpStream;
 use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
     io::{
         as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
-        AsyncReadRent, AsyncWriteRent,
+        AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
     },
-    io::{AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf},
 };
 
 /// ReadHalf.
@@ -21,7 +15,7 @@ pub type TcpReadHalf<'a> = ReadHalf<'a, TcpStream>;
 pub type TcpWriteHalf<'a> = WriteHalf<'a, TcpStream>;
 
 #[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsReadFd for ReadHalf<'t> {
+impl<'t> AsReadFd for TcpReadHalf<'t> {
     fn as_reader_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
         raw_stream.as_reader_fd()
@@ -49,7 +43,7 @@ impl<'t> AsyncReadRent for TcpReadHalf<'t> {
 }
 
 #[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsWriteFd for WriteHalf<'t> {
+impl<'t> AsWriteFd for TcpWriteHalf<'t> {
     fn as_writer_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *(self.0 as *const TcpStream as *mut TcpStream) };
         raw_stream.as_writer_fd()
@@ -94,19 +88,6 @@ pub type TcpOwnedReadHalf = OwnedReadHalf<TcpStream>;
 /// OwnedWriteHalf
 pub type TcpOwnedWriteHalf = OwnedWriteHalf<TcpStream>;
 
-/// Error indicating that two halves were not from the same socket, and thus
-/// could not be reunited.
-pub struct ReuniteError(pub TcpOwnedReadHalf, pub TcpOwnedWriteHalf);
-
-impl fmt::Display for ReuniteError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "tried to reunite halves that are not from the same socket"
-        )
-    }
-}
-
 // impl Error for ReuniteError{}
 
 impl TcpOwnedReadHalf {
@@ -121,31 +102,12 @@ impl TcpOwnedReadHalf {
     }
 }
 
-impl AsReadFd for OwnedReadHalf {
+impl AsReadFd for TcpOwnedReadHalf {
     fn as_reader_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *self.0.get() };
         raw_stream.as_reader_fd()
     }
 }
-
-// impl AsyncReadRent for OwnedReadHalf {
-//     type ReadFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
-//         B: IoBufMut + 'a;
-//     type ReadvFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
-//         B: IoVecBufMut + 'a;
-
-//     fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
-//         // Submit the read operation
-//         let raw_stream = unsafe { &mut *self.0.get() };
-//         raw_stream.read(buf)
-//     }
-
-//     fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
-//         // Submit the read operation
-//         let raw_stream = unsafe { &mut *self.0.get() };
-//         raw_stream.readv(buf)
-//     }
-// }
 
 impl TcpOwnedWriteHalf {
     /// Returns the remote address that this stream is connected to.
@@ -159,51 +121,9 @@ impl TcpOwnedWriteHalf {
     }
 }
 
-impl AsWriteFd for OwnedWriteHalf {
+impl AsWriteFd for TcpOwnedWriteHalf {
     fn as_writer_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *self.0.get() };
         raw_stream.as_writer_fd()
-    }
-}
-
-impl AsyncWriteRent for TcpOwnedWriteHalf {
-    type WriteFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        B: IoBuf + 'a;
-    type WritevFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        B: IoVecBuf + 'a;
-    type FlushFuture<'a> = impl Future<Output = io::Result<()>>;
-    type ShutdownFuture<'a> = impl Future<Output = io::Result<()>>;
-
-    fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
-        // Submit the write operation
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.write(buf)
-    }
-
-    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> Self::WritevFuture<'_, T> {
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.writev(buf_vec)
-    }
-
-    fn flush(&mut self) -> Self::FlushFuture<'_> {
-        // Tcp stream does not need flush.
-        async move { Ok(()) }
-    }
-
-    fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.shutdown()
-    }
-}
-
-impl<T> Drop for OwnedWriteHalf<T>
-where
-    T: AsyncWriteRent,
-{
-    fn drop(&mut self) {
-        let write = unsafe { &mut *self.0.get() };
-        // Notes:: shutdown is an async function but rust currently does not support async drop
-        // this drop will only execute sync part of `shutdown` function.
-        write.shutdown();
     }
 }

--- a/monoio/src/net/tcp/split.rs
+++ b/monoio/src/net/tcp/split.rs
@@ -1,5 +1,9 @@
-
-use std::{error::Error, fmt, future::Future, io, net::SocketAddr};
+use std::{
+    fmt::{self},
+    future::Future,
+    io,
+    net::SocketAddr,
+};
 
 use super::TcpStream;
 use crate::{
@@ -8,9 +12,7 @@ use crate::{
         as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
         AsyncReadRent, AsyncWriteRent,
     },
-    io::{
-        AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
-    },
+    io::{AsyncReadRent, AsyncWriteRent, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf},
 };
 
 /// ReadHalf.
@@ -94,7 +96,6 @@ pub type TcpOwnedWriteHalf = OwnedWriteHalf<TcpStream>;
 
 /// Error indicating that two halves were not from the same socket, and thus
 /// could not be reunited.
-#[derive(Debug)]
 pub struct ReuniteError(pub TcpOwnedReadHalf, pub TcpOwnedWriteHalf);
 
 impl fmt::Display for ReuniteError {
@@ -106,7 +107,7 @@ impl fmt::Display for ReuniteError {
     }
 }
 
-impl Error for ReuniteError {}
+// impl Error for ReuniteError{}
 
 impl TcpOwnedReadHalf {
     /// Returns the remote address that this stream is connected to.
@@ -200,7 +201,9 @@ where
     T: AsyncWriteRent,
 {
     fn drop(&mut self) {
-        let w = unsafe { &mut *self.0.get()};
-        w.shutdown();
+        let write = unsafe { &mut *self.0.get() };
+        // Notes:: shutdown is an async function but rust currently does not support async drop
+        // this drop will only execute sync part of `shutdown` function.
+        write.shutdown();
     }
 }

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use super::split::{TcpOwnedReadHalf, TcpOwnedWriteHalf, TcpReadHalf, TcpWriteHalf};
+
 use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
     driver::{op::Op, shared_fd::SharedFd},
@@ -115,17 +115,6 @@ impl TcpStream {
     ) -> io::Result<()> {
         self.meta.set_tcp_keepalive(time, interval, retries)
     }
-
-    //// Split stream into read and write halves.
-    // #[allow(clippy::needless_lifetimes)]
-    // pub fn split<'a>(&'a mut self) -> (TcpReadHalf<'a>, TcpWriteHalf<'a>) {
-    //     split(self)
-    // }
-
-    // /// Split stream into read and write halves with ownership.
-    // pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
-    //     split_owned(self)
-    // }
 }
 
 impl AsReadFd for TcpStream {

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use super::split::{split, split_owned, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf};
+use super::split::{TcpOwnedReadHalf, TcpOwnedWriteHalf, TcpReadHalf, TcpWriteHalf};
 use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
     driver::{op::Op, shared_fd::SharedFd},
@@ -18,6 +18,7 @@ use crate::{
         as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
         AsyncReadRent, AsyncWriteRent,
     },
+    io::{AsyncReadRent, AsyncWriteRent, Split},
 };
 
 const EMPTY_SLICE: [u8; 0] = [];
@@ -27,6 +28,9 @@ pub struct TcpStream {
     fd: SharedFd,
     meta: StreamMeta,
 }
+
+/// TcpStream is safe to split to two parts
+unsafe impl Split for TcpStream{}
 
 impl TcpStream {
     pub(crate) fn from_shared_fd(fd: SharedFd) -> Self {
@@ -112,16 +116,16 @@ impl TcpStream {
         self.meta.set_tcp_keepalive(time, interval, retries)
     }
 
-    /// Split stream into read and write halves.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn split<'a>(&'a mut self) -> (ReadHalf<'a>, WriteHalf<'a>) {
-        split(self)
-    }
+    //// Split stream into read and write halves.
+    // #[allow(clippy::needless_lifetimes)]
+    // pub fn split<'a>(&'a mut self) -> (TcpReadHalf<'a>, TcpWriteHalf<'a>) {
+    //     split(self)
+    // }
 
-    /// Split stream into read and write halves with ownership.
-    pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
-        split_owned(self)
-    }
+    // /// Split stream into read and write halves with ownership.
+    // pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
+    //     split_owned(self)
+    // }
 }
 
 impl AsReadFd for TcpStream {

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -10,7 +10,6 @@ use std::{
     time::Duration,
 };
 
-
 use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
     driver::{op::Op, shared_fd::SharedFd},
@@ -30,7 +29,7 @@ pub struct TcpStream {
 }
 
 /// TcpStream is safe to split to two parts
-unsafe impl Split for TcpStream{}
+unsafe impl Split for TcpStream {}
 
 impl TcpStream {
     pub(crate) fn from_shared_fd(fd: SharedFd) -> Self {
@@ -193,12 +192,11 @@ impl AsyncWriteRent for TcpStream {
         // We could use shutdown op here, which requires kernel 5.11+.
         // However, for simplicity, we just close the socket using direct syscall.
         let fd = self.as_raw_fd();
-        async move {
-            match unsafe { libc::shutdown(fd, libc::SHUT_WR) } {
-                -1 => Err(io::Error::last_os_error()),
-                _ => Ok(()),
-            }
-        }
+        match unsafe { libc::shutdown(fd, libc::SHUT_WR) } {
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        };
+        async move { Ok(()) }
     }
     #[cfg(windows)]
     fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {

--- a/monoio/src/net/unix/mod.rs
+++ b/monoio/src/net/unix/mod.rs
@@ -13,10 +13,7 @@ pub use datagram::UnixDatagram;
 pub use listener::UnixListener;
 pub use pipe::{new_pipe, Pipe};
 pub use socket_addr::SocketAddr;
-pub use split::{
-    OwnedReadHalf as UnixOwnedReadHalf, OwnedWriteHalf as UnixOwnedWriteHalf,
-    ReadHalf as UnixReadHalf, ReuniteError as UnixReuniteError, WriteHalf as UnixWriteHalf,
-};
+pub use split::{UnixOwnedReadHalf, UnixOwnedWriteHalf, UnixReadHalf, UnixWriteHalf};
 pub use stream::UnixStream;
 
 pub(crate) fn path_offset(sockaddr: &libc::sockaddr_un) -> usize {

--- a/monoio/src/net/unix/split.rs
+++ b/monoio/src/net/unix/split.rs
@@ -1,28 +1,20 @@
-use std::{cell::UnsafeCell, error::Error, fmt, future::Future, io, rc::Rc};
+use std::{io};
 
 use super::{SocketAddr, UnixStream};
 use crate::{
-    buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
     io::{
-        as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
-        AsyncReadRent, AsyncWriteRent,
+        as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper}, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
     },
 };
 
 /// ReadHalf.
-#[derive(Debug)]
-pub struct ReadHalf<'a>(&'a UnixStream);
+pub type UnixReadHalf<'a> = ReadHalf<'a, UnixStream>;
 
 /// WriteHalf.
-#[derive(Debug)]
-pub struct WriteHalf<'a>(&'a UnixStream);
-
-pub(crate) fn split(stream: &mut UnixStream) -> (ReadHalf<'_>, WriteHalf<'_>) {
-    (ReadHalf(&*stream), WriteHalf(&*stream))
-}
+pub type UnixWriteHalf<'a> = WriteHalf<'a, UnixStream>;
 
 #[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsReadFd for ReadHalf<'t> {
+impl<'t> AsReadFd for UnixReadHalf<'t> {
     fn as_reader_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
         raw_stream.as_reader_fd()
@@ -30,124 +22,20 @@ impl<'t> AsReadFd for ReadHalf<'t> {
 }
 
 #[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsyncReadRent for ReadHalf<'t> {
-    type ReadFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoBufMut + 'a,;
-    type ReadvFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoVecBufMut + 'a,;
-
-    fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
-        // Submit the read operation
-        let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
-        raw_stream.read(buf)
-    }
-
-    fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
-        // Submit the read operation
-        let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
-        raw_stream.readv(buf)
-    }
-}
-
-#[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsWriteFd for WriteHalf<'t> {
+impl<'t> AsWriteFd for UnixWriteHalf<'t> {
     fn as_writer_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
         raw_stream.as_writer_fd()
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
-impl<'t> AsyncWriteRent for WriteHalf<'t> {
-    type WriteFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoBuf + 'a;
-    type WritevFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        't: 'a, B: IoVecBuf + 'a,;
-    type FlushFuture<'a> = impl Future<Output = io::Result<()>> where
-        't: 'a,;
-    type ShutdownFuture<'a> = impl Future<Output = io::Result<()>> where
-        't: 'a,;
-
-    fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
-        // Submit the write operation
-        let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
-        raw_stream.write(buf)
-    }
-
-    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> Self::WritevFuture<'_, T> {
-        let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
-        raw_stream.writev(buf_vec)
-    }
-
-    fn flush(&mut self) -> Self::FlushFuture<'_> {
-        // Unix stream does not need flush.
-        async move { Ok(()) }
-    }
-
-    fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
-        let raw_stream = unsafe { &mut *(self.0 as *const UnixStream as *mut UnixStream) };
-        raw_stream.shutdown()
-    }
-}
-
 /// OwnedReadHalf.
-#[derive(Debug)]
-pub struct OwnedReadHalf(Rc<UnsafeCell<UnixStream>>);
+pub type UnixOwnedReadHalf = OwnedReadHalf<UnixStream>;
 
 /// OwnedWriteHalf.
-#[derive(Debug)]
-pub struct OwnedWriteHalf(Rc<UnsafeCell<UnixStream>>);
+pub type UnixOwnedWriteHalf = OwnedWriteHalf<UnixStream>;
 
-pub(crate) fn split_owned(stream: UnixStream) -> (OwnedReadHalf, OwnedWriteHalf) {
-    let stream_shared = Rc::new(UnsafeCell::new(stream));
-    (
-        OwnedReadHalf(stream_shared.clone()),
-        OwnedWriteHalf(stream_shared),
-    )
-}
-
-pub(crate) fn reunite(
-    read: OwnedReadHalf,
-    write: OwnedWriteHalf,
-) -> Result<UnixStream, ReuniteError> {
-    if Rc::ptr_eq(&read.0, &write.0) {
-        drop(write);
-        // This unwrap cannot fail as the api does not allow creating more than two
-        // Arcs, and we just dropped the other half.
-        Ok(Rc::try_unwrap(read.0)
-            .expect("UnixStream: try_unwrap failed in reunite")
-            .into_inner())
-    } else {
-        Err(ReuniteError(read, write))
-    }
-}
-
-/// Error indicating that two halves were not from the same socket, and thus
-/// could not be reunited.
-#[derive(Debug)]
-pub struct ReuniteError(pub OwnedReadHalf, pub OwnedWriteHalf);
-
-impl fmt::Display for ReuniteError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "tried to reunite halves that are not from the same socket"
-        )
-    }
-}
-
-impl Error for ReuniteError {}
-
-impl OwnedReadHalf {
-    /// Attempts to put the two halves of a `TcpStream` back together and
-    /// recover the original socket. Succeeds only if the two halves
-    /// originated from the same call to [`into_split`].
-    ///
-    /// [`into_split`]: TcpStream::into_split()
-    pub fn reunite(self, other: OwnedWriteHalf) -> Result<UnixStream, ReuniteError> {
-        reunite(self, other)
-    }
-
+impl UnixOwnedReadHalf {
     /// Returns the remote address that this stream is connected to.
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         let raw_stream = unsafe { &mut *self.0.get() };
@@ -161,65 +49,16 @@ impl OwnedReadHalf {
     }
 }
 
-impl AsReadFd for OwnedReadHalf {
+impl AsReadFd for UnixOwnedReadHalf {
     fn as_reader_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *self.0.get() };
         raw_stream.as_reader_fd()
     }
 }
 
-impl AsyncReadRent for OwnedReadHalf {
-    type ReadFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
-        B: IoBufMut + 'a;
-    type ReadvFuture<'a, B> = impl std::future::Future<Output = crate::BufResult<usize, B>> where
-        B: IoVecBufMut + 'a;
-
-    fn read<T: IoBufMut>(&mut self, buf: T) -> Self::ReadFuture<'_, T> {
-        // Submit the read operation
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.read(buf)
-    }
-
-    fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
-        // Submit the read operation
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.readv(buf)
-    }
-}
-
-impl AsWriteFd for OwnedWriteHalf {
+impl AsWriteFd for UnixOwnedWriteHalf {
     fn as_writer_fd(&mut self) -> &SharedFdWrapper {
         let raw_stream = unsafe { &mut *self.0.get() };
         raw_stream.as_writer_fd()
-    }
-}
-
-impl AsyncWriteRent for OwnedWriteHalf {
-    type WriteFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        B: IoBuf + 'a;
-    type WritevFuture<'a, B> = impl Future<Output = crate::BufResult<usize, B>> where
-        B: IoVecBuf + 'a;
-    type FlushFuture<'a> = impl Future<Output = io::Result<()>>;
-    type ShutdownFuture<'a> = impl Future<Output = io::Result<()>>;
-
-    fn write<T: IoBuf>(&mut self, buf: T) -> Self::WriteFuture<'_, T> {
-        // Submit the write operation
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.write(buf)
-    }
-
-    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> Self::WritevFuture<'_, T> {
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.writev(buf_vec)
-    }
-
-    fn flush(&mut self) -> Self::FlushFuture<'_> {
-        // Unix stream does not need flush.
-        async move { Ok(()) }
-    }
-
-    fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
-        let raw_stream = unsafe { &mut *self.0.get() };
-        raw_stream.shutdown()
     }
 }

--- a/monoio/src/net/unix/split.rs
+++ b/monoio/src/net/unix/split.rs
@@ -1,10 +1,9 @@
-use std::{io};
+use std::io;
 
 use super::{SocketAddr, UnixStream};
-use crate::{
-    io::{
-        as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper}, OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
-    },
+use crate::io::{
+    as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper},
+    OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf,
 };
 
 /// ReadHalf.

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -5,6 +5,8 @@ use monoio::{
 #[cfg(unix)]
 #[monoio::test_all]
 async fn echo_server() {
+    use monoio::io::Splitable;
+
     const ITER: usize = 1024;
 
     let (tx, rx) = local_sync::oneshot::channel();

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -1,12 +1,10 @@
 use monoio::{
-    io::{self, AsyncReadRentExt, AsyncWriteRentExt},
+    io::{self, AsyncReadRentExt, AsyncWriteRentExt, Splitable},
     net::{TcpListener, TcpStream},
 };
 #[cfg(unix)]
 #[monoio::test_all]
 async fn echo_server() {
-    use monoio::io::Splitable;
-
     const ITER: usize = 1024;
 
     let (tx, rx) = local_sync::oneshot::channel();

--- a/monoio/tests/tcp_into_split.rs
+++ b/monoio/tests/tcp_into_split.rs
@@ -118,19 +118,16 @@ async fn drop_write() -> Result<()> {
     let (read_res, read_buf) = read_half.read(read_buf).await;
     assert_eq!(read_res.unwrap(), MSG.len());
     assert_eq!(&read_buf[..MSG.len()], MSG);
-
     // drop it while the read is in progress
     monoio::spawn(async move {
         monoio::time::sleep(std::time::Duration::from_millis(10)).await;
         drop(write_half);
     });
-
     match read_half.read(read_buf).await.0 {
         Ok(0) => {}
         Ok(len) => panic!("Unexpected read: {} bytes.", len),
         Err(err) => panic!("Unexpected error: {}.", err),
     }
-
     handle.join().unwrap().unwrap();
     Ok(())
 }

--- a/monoio/tests/tcp_into_split.rs
+++ b/monoio/tests/tcp_into_split.rs
@@ -11,6 +11,8 @@ use monoio::{
 #[cfg(unix)]
 #[monoio::test_all]
 async fn split() -> Result<()> {
+    use monoio::io::Splitable;
+
     const MSG: &[u8] = b"split";
 
     let listener = TcpListener::bind("127.0.0.1:0")?;
@@ -52,6 +54,8 @@ async fn split() -> Result<()> {
 #[cfg(unix)]
 #[monoio::test_all(enable_timer = true)]
 async fn reunite() -> Result<()> {
+    use monoio::io::Splitable;
+
     let listener = net::TcpListener::bind("127.0.0.1:0")?;
     let addr = listener.local_addr()?;
 
@@ -81,6 +85,8 @@ async fn reunite() -> Result<()> {
 /// Test that dropping the write half actually closes the stream.
 #[monoio::test_all(enable_timer = true, entries = 1024)]
 async fn drop_write() -> Result<()> {
+    use monoio::io::Splitable;
+
     const MSG: &[u8] = b"split";
 
     let listener = net::TcpListener::bind("127.0.0.1:0")?;

--- a/monoio/tests/tcp_into_split.rs
+++ b/monoio/tests/tcp_into_split.rs
@@ -4,15 +4,13 @@ use std::{
 };
 
 use monoio::{
-    io::{AsyncReadRent, AsyncWriteRentExt},
+    io::{AsyncReadRent, AsyncWriteRentExt, Splitable},
     net::{TcpListener, TcpStream},
     try_join,
 };
 #[cfg(unix)]
 #[monoio::test_all]
 async fn split() -> Result<()> {
-    use monoio::io::Splitable;
-
     const MSG: &[u8] = b"split";
 
     let listener = TcpListener::bind("127.0.0.1:0")?;
@@ -54,8 +52,6 @@ async fn split() -> Result<()> {
 #[cfg(unix)]
 #[monoio::test_all(enable_timer = true)]
 async fn reunite() -> Result<()> {
-    use monoio::io::Splitable;
-
     let listener = net::TcpListener::bind("127.0.0.1:0")?;
     let addr = listener.local_addr()?;
 
@@ -85,8 +81,6 @@ async fn reunite() -> Result<()> {
 /// Test that dropping the write half actually closes the stream.
 #[monoio::test_all(enable_timer = true, entries = 1024)]
 async fn drop_write() -> Result<()> {
-    use monoio::io::Splitable;
-
     const MSG: &[u8] = b"split";
 
     let listener = net::TcpListener::bind("127.0.0.1:0")?;

--- a/monoio/tests/tcp_split.rs
+++ b/monoio/tests/tcp_split.rs
@@ -10,6 +10,8 @@ use monoio::{
 #[cfg(unix)]
 #[monoio::test_all]
 async fn split() -> Result<()> {
+    use monoio::io::Splitable;
+
     const MSG: &[u8] = b"split";
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0")?;

--- a/monoio/tests/tcp_split.rs
+++ b/monoio/tests/tcp_split.rs
@@ -4,14 +4,12 @@ use std::{
 };
 
 use monoio::{
-    io::{AsyncReadRent, AsyncWriteRentExt},
+    io::{AsyncReadRent, AsyncWriteRentExt, Splitable},
     net::TcpStream,
 };
 #[cfg(unix)]
 #[monoio::test_all]
 async fn split() -> Result<()> {
-    use monoio::io::Splitable;
-
     const MSG: &[u8] = b"split";
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0")?;

--- a/monoio/tests/uds_split.rs
+++ b/monoio/tests/uds_split.rs
@@ -1,4 +1,4 @@
-use monoio::io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt};
+use monoio::io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt, Splitable};
 #[cfg(unix)]
 use monoio::net::UnixStream;
 
@@ -11,10 +11,10 @@ use monoio::net::UnixStream;
 #[cfg(unix)]
 #[monoio::test_all(entries = 1024)]
 async fn split() -> std::io::Result<()> {
-    let (mut a, mut b) = UnixStream::pair()?;
+    let (a, b) = UnixStream::pair()?;
 
-    let (mut a_read, mut a_write) = a.split();
-    let (mut b_read, mut b_write) = b.split();
+    let (mut a_read, mut a_write) = a.into_split();
+    let (mut b_read, mut b_write) = b.into_split();
 
     let (a_response, b_response) = futures::future::try_join(
         send_recv_all(&mut a_read, &mut a_write, b"A"),

--- a/monoio/tests/uds_split.rs
+++ b/monoio/tests/uds_split.rs
@@ -11,10 +11,10 @@ use monoio::net::UnixStream;
 #[cfg(unix)]
 #[monoio::test_all(entries = 1024)]
 async fn split() -> std::io::Result<()> {
-    let (a, b) = UnixStream::pair()?;
+    let (mut a, mut b) = UnixStream::pair()?;
 
-    let (mut a_read, mut a_write) = a.into_split();
-    let (mut b_read, mut b_write) = b.into_split();
+    let (mut a_read, mut a_write) = a.split();
+    let (mut b_read, mut b_write) = b.split();
 
     let (a_response, b_response) = futures::future::try_join(
         send_recv_all(&mut a_read, &mut a_write, b"A"),

--- a/monoio/tests/zero_copy.rs
+++ b/monoio/tests/zero_copy.rs
@@ -46,8 +46,8 @@ async fn zero_copy_for_uds() {
     let srv = monoio::net::UnixListener::bind(&sock_path).unwrap();
     let (mut c_tx, mut c_rx) = local_sync::oneshot::channel::<()>();
     monoio::spawn(async move {
-        let stream = UnixStream::connect(&sock_path).await.unwrap();
-        let (mut rx, mut tx) = stream.into_split();
+        let mut stream = UnixStream::connect(&sock_path).await.unwrap();
+        let (mut rx, mut tx) = stream.split();
         tx.write_all(MSG).await.0.unwrap();
         let buf = Vec::<u8>::with_capacity(MSG.len()).slice_mut(0..MSG.len());
         let (res, buf) = rx.read_exact(buf).await;

--- a/monoio/tests/zero_copy.rs
+++ b/monoio/tests/zero_copy.rs
@@ -3,7 +3,7 @@
 async fn zero_copy_for_tcp() {
     use monoio::{
         buf::IoBufMut,
-        io::{zero_copy, AsyncReadRentExt, AsyncWriteRentExt},
+        io::{zero_copy, AsyncReadRentExt, AsyncWriteRentExt, Splitable},
         net::TcpStream,
     };
 


### PR DESCRIPTION
This PR introduces an unsafe split trait for uniforming split logic.

Related: https://github.com/monoio-rs/monoio/pull/1

Note: This PR may break some code which use independent split/into_split method of `TcpStream`, `UnixStream`, etc.

Workaround: just import 'monoio::io::Splitable' to inject uniform `split/into_split` method. Use suggestions from IDE can resolve this import directly.