### PR TITLE
implement from_std for TcpStream

### DIFF
--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -113,6 +113,12 @@ impl TcpStream {
     ) -> io::Result<()> {
         self.meta.set_tcp_keepalive(time, interval, retries)
     }
+
+    /// Creates new `TcpStream` from a `std::net::TcpStream`.
+    pub fn from_std(stream: std::net::TcpStream) -> io::Result<Self> {
+        let fd = stream.into_raw_fd();
+        Ok(Self::from_shared_fd(SharedFd::new(fd)?))
+    }
 }
 
 impl AsReadFd for TcpStream {


### PR DESCRIPTION
I need this method to implement [ntex-monoio](https://github.com/ntex-rs/ntex/pull/137).