### PR TITLE
feat: compatiable with tokio io trait when only legacy is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "monoio-compat",
 
     # Internal
-    "examples"
+    "examples",
+    "examples/tokio-io-compat"
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 edition = "2021"
+license = "MIT/Apache-2.0"
 name = "monoio-examples"
 publish = false
 version = "0.0.0"
@@ -19,9 +20,9 @@ monoio = {path = "../monoio", default-features = false, features = ["async-cance
 hyper = {version = "0.14", features = ["http1", "client", "server", "stream"]}
 
 # For h2 examples
+bytes = {version = "1"}
 h2 = {version = "0.3"}
 http = {version = "0.2"}
-bytes = {version = "1"}
 
 # For hyper and h2 examples
 monoio-compat = {path = "../monoio-compat"}

--- a/examples/tokio-io-compat/Cargo.toml
+++ b/examples/tokio-io-compat/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+edition = "2021"
+license = "MIT/Apache-2.0"
+name = "tokio-io-compat"
+publish = false
+version = "0.0.0"
+
+[dependencies]
+# legacy and tokio-compat enabled, iouring disabled.
+monoio = {path = "../../monoio", default-features = false, features = ["async-cancel", "sync", "bytes", "legacy", "macros", "utils", "tokio-compat"]}
+
+hyper = {version = "0.14", features = ["http1", "client", "server", "stream"]}
+tokio = {version = "1", default-features = false, features = ["io-util"]}
+tower-service = "0.3"

--- a/examples/tokio-io-compat/src/main.rs
+++ b/examples/tokio-io-compat/src/main.rs
@@ -1,0 +1,130 @@
+//! HTTP client example with hyper in compatible mode(without cost).
+//!
+//! It will try to fetch https://www.bytedance.com/ and print the
+//! response.
+//!
+//! It looks like the `hyper_client.rs` in example. The difference is
+//! in this version the tokio AsyncRead and AsyncWrite is implemented
+//! without additional cost because we only enable legacy feature.
+
+use std::{future::Future, pin::Pin};
+
+#[derive(Clone)]
+struct HyperExecutor;
+
+impl<F> hyper::rt::Executor<F> for HyperExecutor
+where
+    F: Future + 'static,
+    F::Output: 'static,
+{
+    #[inline]
+    fn execute(&self, fut: F) {
+        monoio::spawn(fut);
+    }
+}
+
+#[derive(Clone)]
+struct HyperConnector;
+
+impl tower_service::Service<hyper::Uri> for HyperConnector {
+    type Response = HyperConnection;
+
+    type Error = std::io::Error;
+
+    #[allow(clippy::type_complexity)]
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    #[inline]
+    fn poll_ready(
+        &mut self,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: hyper::Uri) -> Self::Future {
+        let host = uri.host().unwrap();
+        let port = uri.port_u16().unwrap_or(80);
+        let address = format!("{host}:{port}");
+
+        #[allow(clippy::type_complexity)]
+        let b: Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>> =
+            Box::pin(async move {
+                let conn = monoio::net::TcpStream::connect(address).await?;
+                let hyper_conn = HyperConnection(conn);
+                Ok(hyper_conn)
+            });
+        // Use transmust to make future Send(infact it is not)
+        unsafe { std::mem::transmute(b) }
+    }
+}
+
+struct HyperConnection(monoio::net::TcpStream);
+
+impl tokio::io::AsyncRead for HyperConnection {
+    #[inline]
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncWrite for HyperConnection {
+    #[inline]
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    #[inline]
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    #[inline]
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}
+
+impl hyper::client::connect::Connection for HyperConnection {
+    #[inline]
+    fn connected(&self) -> hyper::client::connect::Connected {
+        hyper::client::connect::Connected::new()
+    }
+}
+
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl Send for HyperConnection {}
+
+#[monoio::main]
+async fn main() {
+    println!("Running http client");
+    let connector = HyperConnector;
+    let client = hyper::Client::builder()
+        .executor(HyperExecutor)
+        .build::<HyperConnector, hyper::Body>(connector);
+    let res = client
+        .get("https://www.bytedance.com/".parse().unwrap())
+        .await
+        .expect("failed to fetch");
+    println!("Response status: {}", res.status());
+    let body = hyper::body::to_bytes(res.into_body())
+        .await
+        .expect("failed to read body");
+    let body =
+        String::from_utf8(body.into_iter().collect()).expect("failed to convert body to string");
+    println!("Response body: {body}");
+}

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -27,6 +27,7 @@ mio = {version = "0.8", features = [
   "os-ext",
 ], optional = true}
 threadpool = {version = "1", optional = true}
+tokio = {version = "1", default-features = false, optional = true}
 tracing = {version = "0.1", default-features = false, features = [
   "std",
 ], optional = true}
@@ -73,5 +74,7 @@ debug = ["tracing"]
 legacy = ["mio"]
 # iouring support
 iouring = []
+# tokio-compatiable(only have effect when legacy is enabled and iouring is not)
+tokio-compat = ["tokio"]
 # by default both iouring and legacy are enabled
 default = ["async-cancel", "bytes", "iouring", "legacy", "macros", "utils"]

--- a/monoio/src/blocking.rs
+++ b/monoio/src/blocking.rs
@@ -222,14 +222,14 @@ mod tests {
             let begin = std::time::Instant::now();
             let join = crate::spawn_blocking(|| {
                 // Simulate a heavy computation.
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                std::thread::sleep(std::time::Duration::from_millis(400));
                 "hello spawn_blocking!".to_string()
             });
-            let sleep_async = crate::time::sleep(std::time::Duration::from_millis(100));
+            let sleep_async = crate::time::sleep(std::time::Duration::from_millis(400));
             let (result, _) = crate::join!(join, sleep_async);
             let eps = begin.elapsed();
-            assert!(eps < std::time::Duration::from_millis(190));
-            assert!(eps >= std::time::Duration::from_millis(100));
+            assert!(eps < std::time::Duration::from_millis(800));
+            assert!(eps >= std::time::Duration::from_millis(400));
             assert_eq!(result.unwrap(), "hello spawn_blocking!");
         });
     }

--- a/monoio/src/buf/mod.rs
+++ b/monoio/src/buf/mod.rs
@@ -16,7 +16,7 @@ mod slice;
 pub use slice::{IoVecWrapper, IoVecWrapperMut, Slice, SliceMut};
 
 mod raw_buf;
-pub use raw_buf::RawBuf;
+pub use raw_buf::{RawBuf, RawBufVectored};
 
 mod vec_wrapper;
 pub(crate) use vec_wrapper::{read_vec_meta, write_vec_meta};

--- a/monoio/src/buf/raw_buf.rs
+++ b/monoio/src/buf/raw_buf.rs
@@ -99,3 +99,46 @@ impl RawBuf {
         }
     }
 }
+
+/// RawBufVectored behaves like RawBuf.
+/// And user must obey the following restrictions:
+/// 1. await the future with RawBuf Ready before drop the real buffer
+/// 2. make sure the pointer and length is valid before the future Ready
+pub struct RawBufVectored {
+    ptr: *const libc::iovec,
+    len: usize,
+}
+
+impl RawBufVectored {
+    /// Create a new RawBuf with given pointer and length.
+    /// # Safety
+    /// make sure the pointer and length is valid when RawBuf is used.
+    #[inline]
+    pub unsafe fn new(ptr: *const libc::iovec, len: usize) -> Self {
+        Self { ptr, len }
+    }
+}
+
+unsafe impl IoVecBuf for RawBufVectored {
+    #[inline]
+    fn read_iovec_ptr(&self) -> *const libc::iovec {
+        self.ptr
+    }
+
+    #[inline]
+    fn read_iovec_len(&self) -> usize {
+        self.len
+    }
+}
+
+unsafe impl IoVecBufMut for RawBufVectored {
+    fn write_iovec_ptr(&mut self) -> *mut libc::iovec {
+        self.ptr as *mut libc::iovec
+    }
+
+    fn write_iovec_len(&mut self) -> usize {
+        self.len
+    }
+
+    unsafe fn set_init(&mut self, _pos: usize) {}
+}

--- a/monoio/src/driver/op/recv.rs
+++ b/monoio/src/driver/op/recv.rs
@@ -29,6 +29,14 @@ impl<T: IoBufMut> Op<Recv<T>> {
         })
     }
 
+    #[allow(unused)]
+    pub(crate) fn recv_raw(fd: &SharedFd, buf: T) -> Recv<T> {
+        Recv {
+            fd: fd.clone(),
+            buf,
+        }
+    }
+
     pub(crate) async fn read(self) -> BufResult<usize, T> {
         let complete = self.await;
         let res = complete.meta.result.map(|v| v as _);

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -28,6 +28,14 @@ impl<T: IoBuf> Op<Send<T>> {
         })
     }
 
+    #[allow(unused)]
+    pub(crate) fn send_raw(fd: &SharedFd, buf: T) -> Send<T> {
+        Send {
+            fd: fd.clone(),
+            buf,
+        }
+    }
+
     pub(crate) async fn write(self) -> BufResult<usize, T> {
         let complete = self.await;
         (complete.meta.result.map(|v| v as _), complete.data.buf)

--- a/monoio/src/driver/op/write.rs
+++ b/monoio/src/driver/op/write.rs
@@ -100,6 +100,14 @@ impl<T: IoVecBuf> Op<WriteVec<T>> {
         })
     }
 
+    #[allow(unused)]
+    pub(crate) fn writev_raw(fd: &SharedFd, buf_vec: T) -> WriteVec<T> {
+        WriteVec {
+            fd: fd.clone(),
+            buf_vec,
+        }
+    }
+
     pub(crate) async fn write(self) -> BufResult<usize, T> {
         let complete = self.await;
         (complete.meta.result.map(|v| v as _), complete.data.buf_vec)

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -260,6 +260,7 @@ impl tokio::io::AsyncRead for TcpStream {
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut recv, cx));
 
             std::task::Poll::Ready(ret.result.map(|n| {
+                buf.assume_init(n as usize);
                 buf.advance(n as usize);
             }))
         }

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -246,6 +246,62 @@ impl AsyncReadRent for TcpStream {
     }
 }
 
+#[cfg(all(unix, feature = "legacy", feature = "tokio-compat"))]
+impl tokio::io::AsyncRead for TcpStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        unsafe {
+            let slice = buf.unfilled_mut();
+            let raw_buf = crate::buf::RawBuf::new(slice.as_ptr() as *const u8, slice.len());
+            let mut recv = Op::recv_raw(&self.fd, raw_buf);
+            let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut recv, cx));
+
+            std::task::Poll::Ready(ret.result.map(|n| {
+                buf.advance(n as usize);
+            }))
+        }
+    }
+}
+
+#[cfg(all(unix, feature = "legacy", feature = "tokio-compat"))]
+impl tokio::io::AsyncWrite for TcpStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        unsafe {
+            let raw_buf = crate::buf::RawBuf::new(buf.as_ptr() as *const u8, buf.len());
+            let mut send = Op::send_raw(&self.fd, raw_buf);
+            let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut send, cx));
+
+            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        let fd = self.as_raw_fd();
+        let res = match unsafe { libc::shutdown(fd, libc::SHUT_WR) } {
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        };
+        std::task::Poll::Ready(res)
+    }
+}
+
 struct StreamMeta {
     socket: Option<socket2::Socket>,
     meta: UnsafeCell<Meta>,

--- a/monoio/src/net/unix/stream.rs
+++ b/monoio/src/net/unix/stream.rs
@@ -210,6 +210,7 @@ impl tokio::io::AsyncRead for UnixStream {
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut recv, cx));
 
             std::task::Poll::Ready(ret.result.map(|n| {
+                buf.assume_init(n as usize);
                 buf.advance(n as usize);
             }))
         }

--- a/monoio/src/net/unix/stream.rs
+++ b/monoio/src/net/unix/stream.rs
@@ -195,3 +195,59 @@ impl AsyncReadRent for UnixStream {
         op.read()
     }
 }
+
+#[cfg(all(unix, feature = "legacy", feature = "tokio-compat"))]
+impl tokio::io::AsyncRead for UnixStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        unsafe {
+            let slice = buf.unfilled_mut();
+            let raw_buf = crate::buf::RawBuf::new(slice.as_ptr() as *const u8, slice.len());
+            let mut recv = Op::recv_raw(&self.fd, raw_buf);
+            let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut recv, cx));
+
+            std::task::Poll::Ready(ret.result.map(|n| {
+                buf.advance(n as usize);
+            }))
+        }
+    }
+}
+
+#[cfg(all(unix, feature = "legacy", feature = "tokio-compat"))]
+impl tokio::io::AsyncWrite for UnixStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        unsafe {
+            let raw_buf = crate::buf::RawBuf::new(buf.as_ptr() as *const u8, buf.len());
+            let mut send = Op::send_raw(&self.fd, raw_buf);
+            let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut send, cx));
+
+            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        let fd = self.as_raw_fd();
+        let res = match unsafe { libc::shutdown(fd, libc::SHUT_WR) } {
+            -1 => Err(io::Error::last_os_error()),
+            _ => Ok(()),
+        };
+        std::task::Poll::Ready(res)
+    }
+}


### PR DESCRIPTION
Motivation: Now there are so many components using io interface of tokio. We want to make them work in monoio without modification or adding a wrapper layer(in this case there is some runtime cost). If iouring is disable, we can provide poll-like io interface.

Status: Work in progress.