### PR TITLE
chore: improve stream.read examples

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -68,18 +68,16 @@ async fn main() {
 
 async fn echo(stream: TcpStream) -> std::io::Result<()> {
     let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut res;
     loop {
         // read
-        let (res, _buf) = stream.read(buf).await;
-        buf = _buf;
-        let res: usize = res?;
-        if res == 0 {
+        (res, buf) = stream.read(buf).await;
+        if res? == 0 {
             return Ok(());
         }
 
         // write all
-        let (res, _buf) = stream.write_all(buf).await;
-        buf = _buf;
+        (res, buf) = stream.write_all(buf).await;
         res?;
 
         // clear

--- a/README.md
+++ b/README.md
@@ -67,18 +67,16 @@ async fn main() {
 
 async fn echo(stream: TcpStream) -> std::io::Result<()> {
     let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut res;
     loop {
         // read
-        let (res, _buf) = stream.read(buf).await;
-        buf = _buf;
-        let res: usize = res?;
-        if res == 0 {
+        (res, buf) = stream.read(buf).await;
+        if res? == 0 {
             return Ok(());
         }
 
         // write all
-        let (res, _buf) = stream.write_all(buf).await;
-        buf = _buf;
+        (res, buf) = stream.write_all(buf).await;
         res?;
 
         // clear

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -30,18 +30,16 @@ async fn main() {
 
 async fn echo(mut stream: TcpStream) -> std::io::Result<()> {
     let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut res;
     loop {
         // read
-        let (res, _buf) = stream.read(buf).await;
-        buf = _buf;
-        let res: usize = res?;
-        if res == 0 {
+        (res, buf) = stream.read(buf).await;
+        if res? == 0 {
             return Ok(());
         }
 
         // write all
-        let (res, _buf) = stream.write_all(buf).await;
-        buf = _buf;
+        (res, buf) = stream.write_all(buf).await;
         res?;
 
         // clear

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -40,18 +40,16 @@ async fn copy_one_direction<FROM: AsyncReadRent, TO: AsyncWriteRent>(
     to: &mut TO,
 ) -> Result<Vec<u8>, std::io::Error> {
     let mut buf = Vec::with_capacity(8 * 1024);
+    let mut res;
     loop {
         // read
-        let (res, _buf) = from.read(buf).await;
-        buf = _buf;
-        let res: usize = res?;
-        if res == 0 {
+        (res, buf) = from.read(buf).await;
+        if res? == 0 {
             return Ok(buf);
         }
 
         // write all
-        let (res, _buf) = to.write_all(buf).await;
-        buf = _buf;
+        (res, buf) = to.write_all(buf).await;
         res?;
 
         // clear


### PR DESCRIPTION
Just directly assign the output from stream.read to `(res, buf)` instead of create new bindings.

### Suggestion
If the output of `stream.read(buf).await` is a `Result<(usize, Vec<u8>)>` the code could be more simple and more natural:
```rust
async fn echo(mut stream: TcpStream) -> std::io::Result<()> {
    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
    let mut size;
    loop {
        // read
        (size, buf) = stream.read(buf).await?;
        if size == 0 {
            return Ok(());
        }
        // write all
        (size, buf) = stream.write_all(buf).await?;
        // clear
        buf.clear();
    }
}
```
That is just a normal async runtime example would be like.
