### PR TITLE
clean up stable or unused features

### DIFF
--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -9,13 +9,10 @@
 
 #![warn(missing_docs, unreachable_pub)]
 #![allow(stable_features)]
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 #![feature(box_into_inner)]
 #![feature(new_uninit)]
 #![feature(io_error_more)]
-#![feature(stmt_expr_attributes)]
-#![feature(unboxed_closures)]
 #![feature(once_cell)]
 
 #[macro_use]


### PR DESCRIPTION
For Prod usage, it is preferred to use stable, instead of nightly. 

This PR is the first step to clean up stable or unused features, in order to get ride of nightly features.

- generic_associated_types is stable (https://github.com/bytedance/monoio/issues/129)

- stmt_expr_attributes and unboxed_closures are not used in monoio codebase.

