### PR TITLE
fix: accept new thread pool impl

### DIFF
--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -97,7 +97,7 @@ where
     F::Output: 'static,
     D: Buildable + Driver,
 {
-    let mut rt = builder::Buildable::build(&builder::RuntimeBuilder::<D>::new())
+    let mut rt = builder::Buildable::build(builder::RuntimeBuilder::<D>::new())
         .expect("Unable to build runtime.");
     rt.block_on(future)
 }


### PR DESCRIPTION
Current threadpool interface is `Arc<dyn ThreadPool>`, which is not a proper design.
It implies the pool is shared between threads, but it should be desided by the user. And the default thread pool cannot Send, which makes this feature nearly unuseable.

`Box<dyn crate::blocking::ThreadPool + Send + 'static>` is a better design. It does not require sharing or not sharing.