### PR TITLE
Expose MaybeArmedBoxFuture API

### DIFF
--- a/monoio-compat/src/lib.rs
+++ b/monoio-compat/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![feature(new_uninit)]
 
-mod box_future;
+pub mod box_future;
 mod buf;
 
 mod safe_wrapper;


### PR DESCRIPTION
- Useful when porting Tokio specific poll based crates like H2 to monoio