### PR TITLE
Update version and remove Monoio static path

### DIFF
--- a/monoio-compat/Cargo.toml
+++ b/monoio-compat/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT/Apache-2.0"
 name = "monoio-compat"
 readme = "README.md"
 repository = "https://github.com/bytedance/monoio"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
-monoio = {version = "0.1.0", path = "../monoio", default-features = false}
+monoio = {version = "0.1.0", default-features = false}
 reusable-box-future = "0.2"
 tokio = {version = "1", default-features = false, features = ["io-util"]}
 
 [dev-dependencies]
-monoio = {version = "0.1.0", path = "../monoio", features = ["async-cancel", "macros"]}
+monoio = {version = "0.1.0", features = ["async-cancel", "macros"]}


### PR DESCRIPTION
- Bumping up version to release MaybeArmedBoxFuture API
- Removing static monoio package path, so we can use monoio-compat and monoio together in other crates. Fixes " Dependency 'monoio' has different source paths" error

