### PR TITLE
Update monoio-compat version

### DIFF
--- a/monoio-compat/Cargo.toml
+++ b/monoio-compat/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 name = "monoio-compat"
 readme = "README.md"
 repository = "https://github.com/bytedance/monoio"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 monoio = {version = "0.1.0", path = "../monoio", default-features = false}


### PR DESCRIPTION
- Bump up version to release [MaybeArmedBoxFuture API ](https://github.com/bytedance/monoio/pull/170)in monoio-compat crate

