### PR TITLE
refactor: deprecate pin and use std pin; upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
 
     # Internal
     "examples",
-    "examples/tokio-io-compat"
+    "examples/tokio-io-compat",
 ]
+resolver = "2"

--- a/docs/en/io-cancel.md
+++ b/docs/en/io-cancel.md
@@ -46,10 +46,8 @@ let mut buf = vec![0; 1024];
 let canceler = monoio::io::Canceller::new();
 let handle = canceler.handle();
 
-let timer = monoio::time::sleep(std::time::Duration::from_millis(100));
-monoio::pin!(timer);
-let recv = conn.cancelable_read(buf, handle);
-monoio::pin!(recv);
+let mut timer = std::pin::pin!(monoio::time::sleep(std::time::Duration::from_millis(100)));
+let mut recv = std::pin::pin!(conn.cancelable_read(buf, handle));
 
 monoio::select! {
     _ = &mut timer => {

--- a/docs/zh/io-cancel.md
+++ b/docs/zh/io-cancel.md
@@ -46,10 +46,8 @@ let mut buf = vec![0; 1024];
 let canceler = monoio::io::Canceller::new();
 let handle = canceler.handle();
 
-let timer = monoio::time::sleep(std::time::Duration::from_millis(100));
-monoio::pin!(timer);
-let recv = conn.cancelable_read(buf, handle);
-monoio::pin!(recv);
+let mut timer = std::pin::pin!(monoio::time::sleep(std::time::Duration::from_millis(100)));
+let mut recv = std::pin::pin!(conn.cancelable_read(buf, handle));
 
 monoio::select! {
     _ = &mut timer => {

--- a/examples/timer_select.rs
+++ b/examples/timer_select.rs
@@ -1,6 +1,6 @@
 //! An example to illustrate selecting by macro or manually.
 
-use std::future::Future;
+use std::{future::Future, pin::pin};
 
 use monoio::{io::Canceller, net::TcpListener, time::Duration};
 use pin_project_lite::pin_project;
@@ -44,8 +44,7 @@ async fn main() {
     let canceller = Canceller::new();
     let timeout_fut = monoio::time::sleep(Duration::from_millis(100));
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let io_fut = listener.cancelable_accept(canceller.handle());
-    monoio::pin!(io_fut);
+    let mut io_fut = pin!(listener.cancelable_accept(canceller.handle()));
 
     monoio::select! {
         _ = timeout_fut => {

--- a/monoio-compat/src/safe_wrapper.rs
+++ b/monoio-compat/src/safe_wrapper.rs
@@ -79,7 +79,7 @@ impl<T: AsyncReadRent + Unpin + 'static> tokio::io::AsyncRead for StreamWrapper<
                 // there is no data in buffer. we will construct the future
                 let buf = unsafe { this.read_buf.take().unwrap_unchecked() };
                 // we must leak the stream
-                #[allow(clippy::cast_ref_to_mut)]
+                #[allow(cast_ref_to_mut)]
                 let stream = unsafe { &mut *(&this.stream as *const T as *mut T) };
                 this.read_fut.arm_future(AsyncReadRent::read(stream, buf));
             }
@@ -145,7 +145,7 @@ impl<T: AsyncWriteRent + Unpin + 'static> tokio::io::AsyncWrite for StreamWrappe
         unsafe { owned_buf.set_init(len) };
 
         // we must leak the stream
-        #[allow(clippy::cast_ref_to_mut)]
+        #[allow(cast_ref_to_mut)]
         let stream = unsafe { &mut *(&this.stream as *const T as *mut T) };
         this.write_fut
             .arm_future(AsyncWriteRentExt::write_all(stream, owned_buf));
@@ -184,7 +184,7 @@ impl<T: AsyncWriteRent + Unpin + 'static> tokio::io::AsyncWrite for StreamWrappe
         }
 
         if !this.flush_fut.armed() {
-            #[allow(clippy::cast_ref_to_mut)]
+            #[allow(cast_ref_to_mut)]
             let stream = unsafe { &mut *(&this.stream as *const T as *mut T) };
             this.flush_fut.arm_future(stream.flush());
         }
@@ -211,7 +211,7 @@ impl<T: AsyncWriteRent + Unpin + 'static> tokio::io::AsyncWrite for StreamWrappe
         }
 
         if !this.shutdown_fut.armed() {
-            #[allow(clippy::cast_ref_to_mut)]
+            #[allow(cast_ref_to_mut)]
             let stream = unsafe { &mut *(&this.stream as *const T as *mut T) };
             this.shutdown_fut.arm_future(stream.shutdown());
         }

--- a/monoio-compat/src/tcp_unsafe.rs
+++ b/monoio-compat/src/tcp_unsafe.rs
@@ -83,7 +83,7 @@ impl tokio::io::AsyncRead for TcpStreamCompat {
         let raw_buf = this.read_dst.check_and_to_rawbuf(ptr, len);
         if !this.read_fut.armed() {
             // we must leak the stream
-            #[allow(clippy::cast_ref_to_mut)]
+            #[allow(cast_ref_to_mut)]
             let stream = unsafe { &mut *(&this.stream as *const TcpStream as *mut TcpStream) };
             this.read_fut
                 .arm_future(AsyncReadRent::read(stream, raw_buf));
@@ -115,7 +115,7 @@ impl tokio::io::AsyncWrite for TcpStreamCompat {
         let raw_buf = this.write_dst.check_and_to_rawbuf(ptr, len);
         if !this.write_fut.armed() {
             // we must leak the stream
-            #[allow(clippy::cast_ref_to_mut)]
+            #[allow(cast_ref_to_mut)]
             let stream = unsafe { &mut *(&this.stream as *const TcpStream as *mut TcpStream) };
             this.write_fut
                 .arm_future(AsyncWriteRent::write(stream, raw_buf));
@@ -138,7 +138,7 @@ impl tokio::io::AsyncWrite for TcpStreamCompat {
         let this = self.get_mut();
 
         if !this.flush_fut.armed() {
-            #[allow(clippy::cast_ref_to_mut)]
+            #[allow(cast_ref_to_mut)]
             let stream = unsafe { &mut *(&this.stream as *const TcpStream as *mut TcpStream) };
             this.flush_fut.arm_future(stream.flush());
         }
@@ -152,7 +152,7 @@ impl tokio::io::AsyncWrite for TcpStreamCompat {
         let this = self.get_mut();
 
         if !this.shutdown_fut.armed() {
-            #[allow(clippy::cast_ref_to_mut)]
+            #[allow(cast_ref_to_mut)]
             let stream = unsafe { &mut *(&this.stream as *const TcpStream as *mut TcpStream) };
             this.shutdown_fut.arm_future(stream.shutdown());
         }

--- a/monoio-macros/src/entry.rs
+++ b/monoio-macros/src/entry.rs
@@ -458,7 +458,7 @@ pub(crate) fn test_all(args: TokenStream, item: TokenStream) -> TokenStream {
         &format!("legacy_{}", input_legacy.sig.ident),
         input_legacy.sig.ident.span(),
     );
-    config.driver = DriverType::Uring;
+    config.driver = DriverType::Legacy;
     let token_legacy = parse_knobs(input_legacy, true, config);
     output.extend(token_legacy);
 

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -12,26 +12,26 @@ version = "0.1.4"
 
 # common dependencies
 [dependencies]
-monoio-macros = {version = "0.0.3", path = "../monoio-macros", optional = true}
+monoio-macros = { version = "0.0.3", path = "../monoio-macros", optional = true }
 
 auto-const-array = "0.2"
 fxhash = "0.2"
 libc = "0.2"
 pin-project-lite = "0.2"
-socket2 = {version = "0.5", features = ["all"]}
+socket2 = { version = "0.5", features = ["all"] }
 
-bytes = {version = "1", optional = true}
-flume = {version = "0.10", optional = true}
-mio = {version = "0.8", features = [
+bytes = { version = "1", optional = true }
+flume = { version = "0.10", optional = true }
+mio = { version = "0.8", features = [
   "net",
   "os-poll",
   "os-ext",
-], optional = true}
-threadpool = {version = "1", optional = true}
-tokio = {version = "1", default-features = false, optional = true}
-tracing = {version = "0.1", default-features = false, features = [
+], optional = true }
+threadpool = { version = "1", optional = true }
+tokio = { version = "1", default-features = false, optional = true }
+tracing = { version = "0.1", default-features = false, features = [
   "std",
-], optional = true}
+], optional = true }
 
 # windows dependencies(will be added when windows support finished)
 # [target.'cfg(windows)'.dependencies]
@@ -45,10 +45,10 @@ tracing = {version = "0.1", default-features = false, features = [
 
 # unix dependencies
 [target.'cfg(unix)'.dependencies]
-nix = {version = "0.25", optional = true}
+nix = { version = "0.26", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = {version = "0.5", features = ["unstable"]}
+io-uring = { version = "0.6" }
 
 [dev-dependencies]
 futures = "0.3"

--- a/monoio/src/io/util/split.rs
+++ b/monoio/src/io/util/split.rs
@@ -63,7 +63,6 @@ pub trait Splitable {
     fn split(&mut self) -> (Self::Read<'_>, Self::Write<'_>);
 }
 
-#[allow(clippy::cast_ref_to_mut)]
 impl<'t, Inner> AsyncReadRent for ReadHalf<'t, Inner>
 where
     Inner: AsyncReadRent,
@@ -79,6 +78,7 @@ where
         T: IoBufMut,
     {
         // Submit the read operation
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.read(buf)
     }
@@ -86,12 +86,12 @@ where
     #[inline]
     fn readv<T: IoVecBufMut>(&mut self, buf: T) -> Self::ReadvFuture<'_, T> {
         // Submit the read operation
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.readv(buf)
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
 impl<'t, Inner> CancelableAsyncReadRent for ReadHalf<'t, Inner>
 where
     Inner: CancelableAsyncReadRent,
@@ -111,6 +111,7 @@ where
         T: IoBufMut,
     {
         // Submit the read operation
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.cancelable_read(buf, c)
     }
@@ -122,12 +123,12 @@ where
         c: CancelHandle,
     ) -> Self::CancelableReadvFuture<'_, T> {
         // Submit the read operation
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.cancelable_readv(buf, c)
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
 impl<'t, Inner> AsyncWriteRent for WriteHalf<'t, Inner>
 where
     Inner: AsyncWriteRent,
@@ -147,30 +148,33 @@ where
         T: IoBuf,
     {
         // Submit the write operation
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.write(buf)
     }
 
     #[inline]
     fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> Self::WritevFuture<'_, T> {
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.writev(buf_vec)
     }
 
     #[inline]
     fn flush(&mut self) -> Self::FlushFuture<'_> {
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.flush()
     }
 
     #[inline]
     fn shutdown(&mut self) -> Self::ShutdownFuture<'_> {
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.shutdown()
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
 impl<'t, Inner> CancelableAsyncWriteRent for WriteHalf<'t, Inner>
 where
     Inner: CancelableAsyncWriteRent,
@@ -194,6 +198,7 @@ where
         T: IoBuf,
     {
         // Submit the write operation
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.cancelable_write(buf, c)
     }
@@ -204,18 +209,21 @@ where
         buf_vec: T,
         c: CancelHandle,
     ) -> Self::CancelableWritevFuture<'_, T> {
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.cancelable_writev(buf_vec, c)
     }
 
     #[inline]
     fn cancelable_flush(&mut self, c: CancelHandle) -> Self::CancelableFlushFuture<'_> {
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.cancelable_flush(c)
     }
 
     #[inline]
     fn cancelable_shutdown(&mut self, c: CancelHandle) -> Self::CancelableShutdownFuture<'_> {
+        #[allow(cast_ref_to_mut)]
         let raw_stream = unsafe { &mut *(self.0 as *const Inner as *mut Inner) };
         raw_stream.cancelable_shutdown(c)
     }

--- a/monoio/src/macros/pin.rs
+++ b/monoio/src/macros/pin.rs
@@ -88,6 +88,7 @@
 ///     }
 /// }
 /// ```
+#[deprecated(note = "use std::pin::pin instead")]
 #[macro_export]
 macro_rules! pin {
     ($($x:ident),*) => { $(

--- a/monoio/src/macros/select.rs
+++ b/monoio/src/macros/select.rs
@@ -180,8 +180,7 @@
 ///
 /// #[monoio::main(timer_enabled = true)]
 /// async fn main() {
-///     let sleep = time::sleep(Duration::from_millis(50));
-///     monoio::pin!(sleep);
+///     let mut sleep = std::pin::pin!(time::sleep(Duration::from_millis(50)));
 ///
 ///     while !sleep.is_elapsed() {
 ///         monoio::select! {
@@ -216,8 +215,7 @@
 ///
 /// #[monoio::main(timer_enabled = true)]
 /// async fn main() {
-///     let sleep = time::sleep(Duration::from_millis(50));
-///     monoio::pin!(sleep);
+///     let mut sleep = std::pin::pin!(time::sleep(Duration::from_millis(50)));
 ///
 ///     loop {
 ///         monoio::select! {

--- a/monoio/src/net/tcp/split.rs
+++ b/monoio/src/net/tcp/split.rs
@@ -11,7 +11,7 @@ pub type TcpReadHalf<'a> = ReadHalf<'a, TcpStream>;
 /// WriteHalf
 pub type TcpWriteHalf<'a> = WriteHalf<'a, TcpStream>;
 
-#[allow(clippy::cast_ref_to_mut)]
+#[allow(cast_ref_to_mut)]
 impl<'t> AsReadFd for TcpReadHalf<'t> {
     #[inline]
     fn as_reader_fd(&mut self) -> &SharedFdWrapper {
@@ -20,7 +20,7 @@ impl<'t> AsReadFd for TcpReadHalf<'t> {
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
+#[allow(cast_ref_to_mut)]
 impl<'t> AsWriteFd for TcpWriteHalf<'t> {
     #[inline]
     fn as_writer_fd(&mut self) -> &SharedFdWrapper {

--- a/monoio/src/net/unix/split.rs
+++ b/monoio/src/net/unix/split.rs
@@ -12,7 +12,7 @@ pub type UnixReadHalf<'a> = ReadHalf<'a, UnixStream>;
 /// WriteHalf.
 pub type UnixWriteHalf<'a> = WriteHalf<'a, UnixStream>;
 
-#[allow(clippy::cast_ref_to_mut)]
+#[allow(cast_ref_to_mut)]
 impl<'t> AsReadFd for UnixReadHalf<'t> {
     #[inline]
     fn as_reader_fd(&mut self) -> &SharedFdWrapper {
@@ -21,7 +21,7 @@ impl<'t> AsReadFd for UnixReadHalf<'t> {
     }
 }
 
-#[allow(clippy::cast_ref_to_mut)]
+#[allow(cast_ref_to_mut)]
 impl<'t> AsWriteFd for UnixWriteHalf<'t> {
     #[inline]
     fn as_writer_fd(&mut self) -> &SharedFdWrapper {

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -149,7 +149,7 @@ impl<D> Runtime<D> {
                 #[cfg(not(feature = "sync"))]
                 let join = future;
 
-                pin!(join);
+                let mut join = std::pin::pin!(join);
                 set_poll();
                 loop {
                     loop {

--- a/monoio/src/time/driver/sleep.rs
+++ b/monoio/src/time/driver/sleep.rs
@@ -184,7 +184,6 @@ pin_project! {
     ///
     /// [`select!`]: ../macro.select.html
     /// [`monoio::pin!`]: ../macro.pin.html
-    // Alias for old name in 0.2
     #[cfg_attr(docsrs, doc(alias = "Delay"))]
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]

--- a/monoio/tests/tcp_accept.rs
+++ b/monoio/tests/tcp_accept.rs
@@ -1,10 +1,7 @@
-#[cfg(unix)]
 use std::net::{IpAddr, SocketAddr};
 
-#[cfg(unix)]
 use monoio::net::{TcpListener, TcpStream};
 
-#[cfg(unix)]
 macro_rules! test_accept {
     ($(($ident:ident, $target:expr),)*) => {
         $(
@@ -25,7 +22,6 @@ macro_rules! test_accept {
     }
 }
 
-#[cfg(unix)]
 test_accept! {
     (ip_str, "127.0.0.1:0"),
     (host_str, "localhost:0"),

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -2,7 +2,7 @@ use monoio::{
     io::{self, AsyncReadRentExt, AsyncWriteRentExt, Splitable},
     net::{TcpListener, TcpStream},
 };
-#[cfg(unix)]
+
 #[monoio::test_all]
 async fn echo_server() {
     const ITER: usize = 1024;
@@ -62,7 +62,6 @@ async fn echo_server() {
     assert!(rx.await.is_ok());
 }
 
-#[cfg(unix)]
 #[monoio::test_all(timer_enabled = true)]
 async fn rw_able() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -97,7 +96,6 @@ async fn rw_able() {
     assert!(conn.readable(false).await.is_ok());
 }
 
-#[cfg(unix)]
 #[monoio::test_all]
 async fn echo_tfo() {
     use std::net::SocketAddr;

--- a/monoio/tests/tcp_into_split.rs
+++ b/monoio/tests/tcp_into_split.rs
@@ -1,16 +1,14 @@
-#[cfg(unix)]
 use std::{
     io::{Error, ErrorKind, Read, Result, Write},
     net, thread,
 };
 
-#[cfg(unix)]
 use monoio::{
     io::{AsyncReadRent, AsyncWriteRentExt, Splitable},
     net::{TcpListener, TcpStream},
     try_join,
 };
-#[cfg(unix)]
+
 #[monoio::test_all]
 async fn split() -> Result<()> {
     const MSG: &[u8] = b"split";
@@ -51,7 +49,7 @@ async fn split() -> Result<()> {
 
     Ok(())
 }
-#[cfg(unix)]
+
 #[monoio::test_all(enable_timer = true)]
 async fn reunite() -> Result<()> {
     let listener = net::TcpListener::bind("127.0.0.1:0")?;
@@ -78,7 +76,6 @@ async fn reunite() -> Result<()> {
     handle.join().unwrap();
     Ok(())
 }
-#[cfg(unix)]
 
 /// Test that dropping the write half actually closes the stream.
 #[monoio::test_all(enable_timer = true, entries = 1024)]

--- a/monoio/tests/tcp_split.rs
+++ b/monoio/tests/tcp_split.rs
@@ -7,7 +7,7 @@ use monoio::{
     io::{AsyncReadRent, AsyncWriteRentExt, Splitable},
     net::TcpStream,
 };
-#[cfg(unix)]
+
 #[monoio::test_all]
 async fn split() -> Result<()> {
     const MSG: &[u8] = b"split";

--- a/monoio/tests/udp.rs
+++ b/monoio/tests/udp.rs
@@ -1,7 +1,5 @@
-#[cfg(unix)]
 use monoio::net::udp::UdpSocket;
 
-#[cfg(unix)]
 #[monoio::test_all]
 async fn connect() {
     const MSG: &str = "foo bar baz";
@@ -22,7 +20,6 @@ async fn connect() {
     assert_eq!(active.peer_addr().unwrap(), passive_addr);
 }
 
-#[cfg(unix)]
 #[monoio::test_all]
 async fn send_to() {
     const MSG: &str = "foo bar baz";
@@ -60,7 +57,6 @@ async fn send_to() {
     must_success!(passive3.recv_from(vec![0; 20]).await, active_addr);
 }
 
-#[cfg(unix)]
 #[monoio::test_all(timer_enabled = true)]
 async fn rw_able() {
     const MSG: &str = "foo bar baz";
@@ -83,13 +79,12 @@ async fn rw_able() {
     assert!(passive.readable(false).await.is_ok());
 }
 
-#[cfg(unix)]
 #[monoio::test_all(timer_enabled = true)]
 async fn cancel_recv_from() {
     let passive = UdpSocket::bind("127.0.0.1:0").unwrap();
     let canceller = monoio::io::Canceller::new();
     let recv = passive.cancelable_recv_from(vec![0; 20], canceller.handle());
-    monoio::pin!(recv);
+    let mut recv = std::pin::pin!(recv);
 
     monoio::select! {
         _ = monoio::time::sleep(std::time::Duration::from_millis(50)) => {

--- a/monoio/tests/uds_cred.rs
+++ b/monoio/tests/uds_cred.rs
@@ -1,10 +1,6 @@
-#[cfg(unix)]
-use libc::getegid;
-#[cfg(unix)]
-use libc::geteuid;
-#[cfg(unix)]
+use libc::{getegid, geteuid};
 use monoio::net::UnixStream;
-#[cfg(unix)]
+
 #[monoio::test_all]
 async fn test_socket_pair() {
     let (a, b) = UnixStream::pair().unwrap();

--- a/monoio/tests/uds_split.rs
+++ b/monoio/tests/uds_split.rs
@@ -1,7 +1,7 @@
-#[cfg(unix)]
-use monoio::io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt, Splitable};
-#[cfg(unix)]
-use monoio::net::UnixStream;
+use monoio::{
+    io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt, Splitable},
+    net::UnixStream,
+};
 
 /// Checks that `UnixStream` can be split into a read half and a write half
 /// using `UnixStream::split` and `UnixStream::split_mut`.
@@ -9,7 +9,6 @@ use monoio::net::UnixStream;
 /// Verifies that the implementation of `AsyncWrite::poll_shutdown` shutdowns
 /// the stream for writing by reading to the end of stream on the other side of
 /// the connection.
-#[cfg(unix)]
 #[monoio::test_all(entries = 1024)]
 async fn split() -> std::io::Result<()> {
     let (mut a, mut b) = UnixStream::pair()?;
@@ -28,7 +27,6 @@ async fn split() -> std::io::Result<()> {
 
     Ok(())
 }
-#[cfg(unix)]
 
 async fn send_recv_all<R: AsyncReadRent, W: AsyncWriteRent>(
     read: &mut R,

--- a/monoio/tests/uds_stream.rs
+++ b/monoio/tests/uds_stream.rs
@@ -1,11 +1,9 @@
-#[cfg(unix)]
 use futures::future::try_join;
-#[cfg(unix)]
-use monoio::io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt};
-#[cfg(unix)]
-use monoio::net::{UnixListener, UnixStream};
+use monoio::{
+    io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt},
+    net::{UnixListener, UnixStream},
+};
 
-#[cfg(unix)]
 #[monoio::test_all]
 async fn accept_read_write() -> std::io::Result<()> {
     let dir = tempfile::Builder::new()
@@ -33,7 +31,6 @@ async fn accept_read_write() -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 #[monoio::test_all]
 async fn shutdown() -> std::io::Result<()> {
     let dir = tempfile::Builder::new()


### PR DESCRIPTION
1. Use `std::pin::pin` instead of `monoio::pin`
2. Set `resolver = "2"` in root manifest
3. Fix `test_all` macro generating driver type
4. Upgrade `io_uring` and adaptation
5. Solve all test warning for macos