### PR TITLE
feat: implement buffer primitives on windows

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -34,14 +34,9 @@ tracing = { version = "0.1", default-features = false, features = [
 ], optional = true }
 
 # windows dependencies(will be added when windows support finished)
-# [target.'cfg(windows)'.dependencies]
-# windows = {version = "0.43.0", features = [
-#   "Data_Xml_Dom",
-#   "Win32_Foundation",
-#   "Win32_Security",
-#   "Win32_System_Threading",
-#   "Win32_UI_WindowsAndMessaging",
-# ]}
+[dependencies.windows-sys]
+features = ["Win32_Foundation", "Win32_Networking_WinSock"]
+version = "0.48.0"
 
 # unix dependencies
 [target.'cfg(unix)'.dependencies]

--- a/monoio/src/buf/io_vec_buf.rs
+++ b/monoio/src/buf/io_vec_buf.rs
@@ -1,5 +1,6 @@
 // use super::shared_buf::Shared;
 
+#[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::WSABUF;
 
 /// An `io_uring` compatible iovec buffer.

--- a/monoio/src/buf/io_vec_buf.rs
+++ b/monoio/src/buf/io_vec_buf.rs
@@ -33,7 +33,7 @@ pub unsafe trait IoVecBuf: Unpin + 'static {
 
     #[cfg(windows)]
     fn read_wsabuf_ptr(&self) -> *const WSABUF;
-    
+
     #[cfg(windows)]
     fn read_wsabuf_len(&self) -> usize;
 }

--- a/monoio/src/buf/raw_buf.rs
+++ b/monoio/src/buf/raw_buf.rs
@@ -1,5 +1,6 @@
 use std::ptr::null;
 
+#[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::WSABUF;
 
 use super::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut};

--- a/monoio/src/buf/vec_wrapper.rs
+++ b/monoio/src/buf/vec_wrapper.rs
@@ -1,3 +1,4 @@
+#[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::WSABUF;
 
 use super::{IoVecBuf, IoVecBufMut};


### PR DESCRIPTION
Implements `IoVecBuf` and `IoVecBufMut` on Windows.

relevant: https://github.com/bytedance/monoio/issues/87