### PR TITLE
IoUring Driver micro-optimization

### DIFF
--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -332,19 +332,14 @@ impl UringInner {
     fn submit(&mut self) -> io::Result<()> {
         loop {
             match self.uring.submit() {
-                Ok(_) => {
-                    self.uring.submission().sync();
-                    return Ok(());
-                }
                 Err(ref e)
                     if e.kind() == io::ErrorKind::Other
                         || e.kind() == io::ErrorKind::ResourceBusy =>
                 {
                     self.tick();
                 }
-                Err(e) => {
-                    return Err(e);
-                }
+                Ok(_) => return Ok(()),
+                Err(e) => return Err(e),
             }
         }
     }

--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -338,8 +338,7 @@ impl UringInner {
                 {
                     self.tick();
                 }
-                Ok(_) => return Ok(()),
-                Err(e) => return Err(e),
+                e => return e.map(|_| ()),
             }
         }
     }

--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -314,8 +314,7 @@ impl Driver for IoUringDriver {
 
 impl UringInner {
     fn tick(&mut self) {
-        let mut cq = self.uring.completion();
-        cq.sync();
+        let cq = self.uring.completion();
 
         for cqe in cq {
             if cqe.user_data() >= MIN_REVERSED_USERDATA {


### PR DESCRIPTION
### General micro-optimization to io-uring driver cold path
- removed `cq.sync()` in `tick()` function because `self.uring.completion()` already load the head atomic value of the cq ring
- removed `self.uring.submission().sync();` in `submit()` because of it produces unnecessary atomic loads and writes to the sq ring:
  - one `tail` read on submission()
  - one `head` atomic read on `submission()`
  - one `head` atomic read on `sync()`
  - one `tail` atomic write on `sync()` with the same value read before
  - one `tail` atomic write on `SubmissionQueue::drop()` after the function return
- simplified code in the branch of `submit()`
- proposal for linear match of `user_data()` in `tick()` function