### PR TITLE
Fixed bug when on Linux with iouring feature the library didn't compile with an error

### DIFF
--- a/monoio/src/builder.rs
+++ b/monoio/src/builder.rs
@@ -260,7 +260,7 @@ impl RuntimeBuilder<TimeDriver<FusionDriver>> {
 
     /// Build the runtime.
     #[cfg(all(target_os = "linux", feature = "iouring", not(feature = "legacy")))]
-    pub fn build(&self) -> io::Result<crate::FusionRuntime<TimeDriver<IoUringDriver>>> {
+    pub fn build(self) -> io::Result<crate::FusionRuntime<TimeDriver<IoUringDriver>>> {
         let builder = RuntimeBuilder::<TimeDriver<IoUringDriver>> {
             entries: self.entries,
             urb: self.urb,


### PR DESCRIPTION
```
error[E0507]: cannot move out of 'self.urb' which is behind a shared reference
     urb: self. urb,
move occurs because 'self.urb' has type 'io_uring::Builder', which does not implement the 'Copy' trait
```