### PR TITLE
Fix a tiny issue with BufWriter

### DIFF
--- a/monoio/src/io/util/buf_writer.rs
+++ b/monoio/src/io/util/buf_writer.rs
@@ -119,7 +119,7 @@ impl<W: AsyncWriteRent> AsyncWriteRent for BufWriter<W> {
                 let owned_buf = self.buf.as_mut().unwrap();
                 owned_buf
                     .as_mut_ptr()
-                    .add(self.pos)
+                    .add(self.cap)
                     .copy_from_nonoverlapping(buf.read_ptr(), amt);
             }
             self.cap += amt;

--- a/monoio/tests/buf_writter.rs
+++ b/monoio/tests/buf_writter.rs
@@ -1,0 +1,31 @@
+use monoio::{
+    io::{AsyncReadRent, AsyncWriteRent, BufReader, BufWriter, Splitable},
+    net::{TcpListener, TcpStream},
+};
+
+#[monoio::test_all]
+async fn ensure_buf_writter_write_properly() {
+    let srv = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = srv.local_addr().unwrap();
+
+    monoio::spawn(async move {
+        let stream = TcpStream::connect(&addr).await.unwrap();
+        let (_, stream_write) = stream.into_split();
+
+        let mut buf_w = BufWriter::new(stream_write);
+        assert!(buf_w.write(&[b'1']).await.0.is_ok());
+        assert!(buf_w.write(&[b'2']).await.0.is_ok());
+        assert!(buf_w.write(&[b'3']).await.0.is_ok());
+        assert!(buf_w.flush().await.is_ok());
+    });
+
+    let (stream, _) = srv.accept().await.unwrap();
+    let (rd, _) = stream.into_split();
+
+    let s: Vec<u8> = Vec::with_capacity(16);
+    let mut buf = BufReader::new(rd);
+    let (size, s) = buf.read(s).await;
+
+    assert!(size.is_ok());
+    assert_eq!(s, b"123");
+}


### PR DESCRIPTION
BufWriter had a tiny issue: the `cap` was not updated, which would cause successive writes to erase start from the beginning each time.
