### PR TITLE
Integrate `release-plz` to automate release & crate publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5.34
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,33 @@
+[workspace]
+allow_dirty = false
+changelog_update = true
+dependencies_update = true
+git_release_enable = false
+pr_labels = ["release"]
+publish_allow_dirty = false
+semver_check = true
+publish_timeout = "10m"
+
+[[package]]
+name = "monoio"
+changelog_include = ["monoio-macros"]
+changelog_path = "CHANGELOG.md"
+changelog_update = true
+git_release_enable = true
+publish = true
+
+[[package]]
+name = "monoio-macros"
+changelog_include = []
+changelog_path = "monoio-macros/CHANGELOG.md"
+changelog_update = true
+git_release_enable = true
+publish = true
+
+[[package]]
+name = "monoio-compat"
+changelog_include = []
+changelog_path = "monoio-compat/CHANGELOG.md"
+changelog_update = true
+git_release_enable = true
+publish = true


### PR DESCRIPTION
Following https://github.com/bytedance/monoio/issues/223 this is the corresponding workflow needed to integrate it.

For the tokens creation and set up of the whole things, you'll need to refer to this: https://release-plz.ieni.dev/docs/github/token