### PR TITLE
[ISSUE #231] Enhance CI

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -22,7 +22,7 @@ cd "${PROJECT_DIR}"/monoio
 "${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,legacy,macros,utils"
 "${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,legacy,macros,utils" --release
 
-if [ "${TARGET}" = "x86_64-unknown-linux-gnu" ]; then
+if [ "${TARGET}" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "i686-unknown-linux-gnu" ]; then
 
     # only enabled uring driver
     "${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,iouring,macros,utils"

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -45,7 +45,12 @@ cd "${PROJECT_DIR}"/monoio-compat
 "${CARGO}" test --target "${TARGET}"
 "${CARGO}" test --target "${TARGET}" --release
 
+"${CARGO}" test --target "${TARGET}" --no-default-features --features hyper
+"${CARGO}" test --target "${TARGET}" --no-default-features --features hyper --release
+
 if [ "${CHANNEL}" == "nightly" ]; then
     "${CARGO}" test --target "${TARGET}" --all-features
     "${CARGO}" test --target "${TARGET}" --all-features --release
 fi
+
+# todo maybe we should test examples here ?

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -18,11 +18,26 @@ export RUST_BACKTRACE=1
 # test monoio mod
 cd "${PROJECT_DIR}"/monoio
 
-"${CARGO}" test --target "${TARGET}"
-"${CARGO}" test --target "${TARGET}" --release
+# only enable legacy driver
+"${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,legacy,macros,utils"
+"${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,legacy,macros,utils" --release
 
-"${CARGO}" test --target "${TARGET}" --all-features
-"${CARGO}" test --target "${TARGET}" --all-features --release
+if [ "${TARGET}" = "x86_64-unknown-linux-gnu" ]; then
+
+    # only enabled uring driver
+    "${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,iouring,macros,utils"
+    "${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,iouring,macros,utils" --release
+
+    # enable uring+legacy driver
+    "${CARGO}" test --target "${TARGET}"
+    "${CARGO}" test --target "${TARGET}" --release
+
+    if [ "${CHANNEL}" == "nightly" ]; then
+        "${CARGO}" test --target "${TARGET}" --all-features
+        "${CARGO}" test --target "${TARGET}" --all-features --release
+    fi
+
+fi
 
 # test monoio-compat mod
 cd "${PROJECT_DIR}"/monoio-compat
@@ -30,5 +45,7 @@ cd "${PROJECT_DIR}"/monoio-compat
 "${CARGO}" test --target "${TARGET}"
 "${CARGO}" test --target "${TARGET}" --release
 
-"${CARGO}" test --target "${TARGET}" --all-features
-"${CARGO}" test --target "${TARGET}" --all-features --release
+if [ "${CHANNEL}" == "nightly" ]; then
+    "${CARGO}" test --target "${TARGET}" --all-features
+    "${CARGO}" test --target "${TARGET}" --all-features --release
+fi

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+set -ex
+
+CARGO=cargo
+if [ "${CROSS}" = "1" ]; then
+    export CARGO_NET_RETRY=5
+    export CARGO_NET_TIMEOUT=10
+
+    cargo install cross
+    CARGO=cross
+fi
+
+# If a test crashes, we want to know which one it was.
+export RUST_TEST_THREADS=1
+export RUST_BACKTRACE=1
+
+# test monoio mod
+cd "${PROJECT_DIR}"/monoio
+
+"${CARGO}" test --target "${TARGET}"
+"${CARGO}" test --target "${TARGET}" --release
+
+"${CARGO}" test --target "${TARGET}" --all-features
+"${CARGO}" test --target "${TARGET}" --all-features --release
+
+# test monoio-compat mod
+cd "${PROJECT_DIR}"/monoio-compat
+
+"${CARGO}" test --target "${TARGET}"
+"${CARGO}" test --target "${TARGET}" --release
+
+"${CARGO}" test --target "${TARGET}" --all-features
+"${CARGO}" test --target "${TARGET}" --all-features --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           command: check
           args: --no-default-features
-      - name: Run cargo check with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -74,10 +69,11 @@ jobs:
           x86_64-apple-darwin,
 #          aarch64-apple-darwin,
 
-          x86_64-pc-windows-gnu,
-          x86_64-pc-windows-msvc,
-          i686-pc-windows-gnu,
-          i686-pc-windows-msvc,
+          # unsupported yet
+#          x86_64-pc-windows-gnu,
+#          x86_64-pc-windows-msvc,
+#          i686-pc-windows-gnu,
+#          i686-pc-windows-msvc,
         ]
         channel: [stable, nightly]
         include:
@@ -103,11 +99,12 @@ jobs:
 #          - target: aarch64-apple-darwin
 #            os: macos-latest
 
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-          - target: x86_64-pc-windows-gnu
-            os: windows-latest
-          - target: i686-pc-windows-msvc
-            os: windows-latest
-          - target: i686-pc-windows-gnu
-            os: windows-latest
+          # unsupported yet
+#          - target: x86_64-pc-windows-msvc
+#            os: windows-latest
+#          - target: x86_64-pc-windows-gnu
+#            os: windows-latest
+#          - target: i686-pc-windows-msvc
+#            os: windows-latest
+#          - target: i686-pc-windows-gnu
+#            os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 #          loongarch64-unknown-linux-gnu,
 
           x86_64-apple-darwin,
-#          aarch64-apple-darwin,
+          aarch64-apple-darwin,
 
           # unsupported yet
 #          x86_64-pc-windows-gnu,
@@ -96,8 +96,8 @@ jobs:
 
           - target: x86_64-apple-darwin
             os: macos-latest
-#          - target: aarch64-apple-darwin
-#            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-14
 
           # unsupported yet
 #          - target: x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 #          loongarch64-unknown-linux-gnu,
 
           x86_64-apple-darwin,
-#          aarch64-apple-darwin,
+          aarch64-apple-darwin,
 
           # unsupported yet
 #          x86_64-pc-windows-gnu,
@@ -96,8 +96,8 @@ jobs:
 
           - target: x86_64-apple-darwin
             os: macos-latest
-#          - target: aarch64-apple-darwin
-#            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
 
           # unsupported yet
 #          - target: x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
           aarch64-unknown-linux-gnu,
           armv7-unknown-linux-gnueabihf,
           riscv64gc-unknown-linux-gnu,
-          loongarch64-unknown-linux-gnu,
           s390x-unknown-linux-gnu,
 #          mips64-unknown-linux-muslabi64,
+#          loongarch64-unknown-linux-gnu,
 
           x86_64-apple-darwin,
 #          aarch64-apple-darwin,
@@ -87,11 +87,11 @@ jobs:
             os: ubuntu-latest
           - target: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
-          - target: loongarch64-unknown-linux-gnu
-            os: ubuntu-latest
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
 #          - target: mips64-unknown-linux-muslabi64
+#            os: ubuntu-latest
+#          - target: loongarch64-unknown-linux-gnu
 #            os: ubuntu-latest
 
           - target: x86_64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,12 @@ on:
       - '**.png'
 
 env:
-  RUST_TOOLCHAIN: nightly
   TOOLCHAIN_PROFILE: minimal
   CARGO_TERM_COLOR: always
 
 jobs:
-  lints:
-    name: Run cargo fmt and cargo clippy
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -26,7 +24,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ matrix.target == 'i686-pc-windows-gnu' && format('{0}-i686-pc-windows-gnu', matrix.channel) || matrix.channel }}
+          target: ${{ matrix.target }}
           override: true
           components: rustfmt, clippy
       - name: Cache
@@ -51,64 +50,64 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
-  test:
-    name: Run cargo test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-      - name: Cache
-        uses: Swatinem/rust-cache@v1
-      - name: Run cargo test --no-run
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --no-run
-      - name: Run cargo test
-        run: sudo bash -c "ulimit -Sl 512 && ulimit -Hl 512 && sudo -u runner RUSTUP_TOOLCHAIN=nightly /home/runner/.cargo/bin/cargo test --all-features"
+      - env:
+          CHANNEL: ${{ matrix.channel }}
+          CROSS: ${{ !startsWith(matrix.target, 'x86_64') && contains(matrix.target, 'linux') && '1' || '0' }}
+          TARGET: ${{ matrix.target }}
+          OS: ${{ matrix.os }}
+          PROJECT_DIR: ${{ github.workspace }}
+        run: sh .github/workflows/ci.sh
 
-  test-macos:
-    name: Run cargo test on macos
-    runs-on: macos-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-      - name: Cache
-        uses: Swatinem/rust-cache@v1
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          x86_64-unknown-linux-gnu,
+          i686-unknown-linux-gnu,
+          aarch64-unknown-linux-gnu,
+          armv7-unknown-linux-gnueabihf,
+          riscv64gc-unknown-linux-gnu,
+          loongarch64-unknown-linux-gnu,
+          s390x-unknown-linux-gnu,
+#          mips64-unknown-linux-muslabi64,
 
-  # test-windows:
-  #   name: Run cargo test on windows
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v2
-  #     - name: Install toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: ${{ env.TOOLCHAIN_PROFILE }}
-  #         toolchain: ${{ env.RUST_TOOLCHAIN }}
-  #         override: true
-  #     - name: Run cargo test
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: test
-  #         args: --all-features
-  #         toolchain: ${{ env.RUST_TOOLCHAIN }}
+          x86_64-apple-darwin,
+#          aarch64-apple-darwin,
+
+          x86_64-pc-windows-gnu,
+          x86_64-pc-windows-msvc,
+          i686-pc-windows-gnu,
+          i686-pc-windows-msvc,
+        ]
+        channel: [stable, nightly]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+          - target: riscv64gc-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: loongarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: s390x-unknown-linux-gnu
+            os: ubuntu-latest
+#          - target: mips64-unknown-linux-muslabi64
+#            os: ubuntu-latest
+
+          - target: x86_64-apple-darwin
+            os: macos-latest
+#          - target: aarch64-apple-darwin
+#            os: macos-latest
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-pc-windows-gnu
+            os: windows-latest
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+          - target: i686-pc-windows-gnu
+            os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 #          loongarch64-unknown-linux-gnu,
 
           x86_64-apple-darwin,
-          aarch64-apple-darwin,
+#          aarch64-apple-darwin,
 
           # unsupported yet
 #          x86_64-pc-windows-gnu,
@@ -96,8 +96,8 @@ jobs:
 
           - target: x86_64-apple-darwin
             os: macos-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
+#          - target: aarch64-apple-darwin
+#            os: macos-latest
 
           # unsupported yet
 #          - target: x86_64-pc-windows-msvc

--- a/monoio-compat/Cargo.toml
+++ b/monoio-compat/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/bytedance/monoio"
 version = "0.2.1"
 
 [dependencies]
-monoio = { version = "0.2.0", path = "../monoio", default-features = false }
+monoio = { version = "0.2.0", path = "../monoio", default-features = false, features = ["legacy"] }
 reusable-box-future = "0.2"
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 
@@ -25,5 +25,7 @@ monoio = { version = "0.2.0", path = "../monoio", features = [
 ] }
 
 [features]
+# use nightly only feature flags
+unstable = ["monoio/unstable"]
 # this is an experimental feature
 hyper = ["dep:hyper", "dep:pin-project-lite", "monoio/poll-io"]

--- a/monoio-compat/src/lib.rs
+++ b/monoio-compat/src/lib.rs
@@ -1,6 +1,6 @@
 //! For compat with tokio AsyncRead and AsyncWrite.
 
-#![feature(new_uninit)]
+#![cfg_attr(feature = "unstable", feature(new_uninit))]
 
 pub mod box_future;
 mod buf;

--- a/monoio-macros/src/entry.rs
+++ b/monoio-macros/src/entry.rs
@@ -349,9 +349,17 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     } else {
         quote! {}
     };
-    let cfg_attr = if config.driver == DriverType::Uring && is_test {
-        quote! {
-            #[cfg(all(target_os = "linux", feature = "iouring"))]
+    let cfg_attr = if is_test {
+        match config.driver {
+            DriverType::Legacy => quote! {
+                #[cfg(all(target_os = "linux", feature = "legacy"))]
+            },
+            DriverType::Uring => quote! {
+                #[cfg(all(target_os = "linux", feature = "iouring"))]
+            },
+            DriverType::Fusion => quote! {
+                #[cfg(target_os = "linux")]
+            },
         }
     } else {
         quote! {}

--- a/monoio-macros/src/entry.rs
+++ b/monoio-macros/src/entry.rs
@@ -351,7 +351,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     };
     let cfg_attr = if config.driver == DriverType::Uring && is_test {
         quote! {
-            #[cfg(target_os = "linux")]
+            #[cfg(all(target_os = "linux", feature = "iouring"))]
         }
     } else {
         quote! {}

--- a/monoio-macros/src/entry.rs
+++ b/monoio-macros/src/entry.rs
@@ -352,13 +352,13 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     let cfg_attr = if is_test {
         match config.driver {
             DriverType::Legacy => quote! {
-                #[cfg(all(target_os = "linux", feature = "legacy"))]
+                #[cfg(feature = "legacy")]
             },
             DriverType::Uring => quote! {
                 #[cfg(all(target_os = "linux", feature = "iouring"))]
             },
             DriverType::Fusion => quote! {
-                #[cfg(target_os = "linux")]
+                #[cfg(any(feature = "legacy", feature = "iouring"))]
             },
         }
     } else {

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.48.0"
 nix = { version = "0.26", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = { version = "0.6" }
+io-uring = { version = "0.6", optional = true }
 
 [dev-dependencies]
 futures = "0.3"
@@ -75,7 +75,7 @@ debug = ["tracing"]
 # enable legacy driver support(will make monoio available for older kernel and macOS)
 legacy = ["mio"]
 # iouring support
-iouring = []
+iouring = ["io-uring"]
 # tokio-compatible(only have effect when legacy is enabled and iouring is not)
 tokio-compat = ["tokio"]
 # (experimental)enable poll-io to convert structs to structs that impl tokio's poll io

--- a/monoio/src/driver/op/read.rs
+++ b/monoio/src/driver/op/read.rs
@@ -82,7 +82,7 @@ impl<T: IoBufMut> OpAble for Read<T> {
             fd,
             self.buf.write_ptr() as _,
             self.buf.bytes_total(),
-            seek_offset
+            seek_offset as _
         ));
 
         #[cfg(target_os = "macos")]

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -43,6 +43,7 @@ impl<T: IoBuf> Op<Send<T>> {
 impl<T: IoBuf> OpAble for Send<T> {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        #[allow(deprecated)]
         #[cfg(feature = "zero-copy")]
         fn zero_copy_flag_guard<T: IoBuf>(buf: &T) -> libc::c_int {
             // TODO: use libc const after supported.
@@ -52,11 +53,8 @@ impl<T: IoBuf> OpAble for Send<T> {
             // see also: https://www.kernel.org/doc/html/v4.16/networking/msg_zerocopy.html
             const MSG_ZEROCOPY_THRESHOLD: usize = 10 * 1024 * 1024;
             if buf.bytes_init() >= MSG_ZEROCOPY_THRESHOLD {
-                #[allow(deprecated)]
-                libc::MSG_NOSIGNAL as libc::c_int
-                    | MSG_ZEROCOPY
+                libc::MSG_NOSIGNAL as libc::c_int | MSG_ZEROCOPY
             } else {
-                #[allow(deprecated)]
                 libc::MSG_NOSIGNAL as libc::c_int
             }
         }

--- a/monoio/src/driver/op/write.rs
+++ b/monoio/src/driver/op/write.rs
@@ -69,7 +69,7 @@ impl<T: IoBuf> OpAble for Write<T> {
             fd,
             self.buf.read_ptr() as _,
             self.buf.bytes_init(),
-            seek_offset
+            seek_offset as _
         ));
 
         #[cfg(target_os = "macos")]

--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -56,9 +56,9 @@ pub use {builder::FusionDriver, runtime::FusionRuntime};
 /// Basic usage
 ///
 /// ```no_run
-/// #[cfg(not(all(target_os = "linux", feature = "iouring")))]
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     monoio::start::<monoio::LegacyDriver, _>(async {
+///     #[cfg(not(all(target_os = "linux", feature = "iouring")))]
+///     let r = monoio::start::<monoio::LegacyDriver, _>(async {
 ///         // Open a file
 ///         let file = monoio::fs::File::open("hello.txt").await?;
 ///
@@ -73,7 +73,10 @@ pub use {builder::FusionDriver, runtime::FusionRuntime};
 ///         println!("{:?}", &buf[..n]);
 ///
 ///         Ok(())
-///     })
+///     });
+///     #[cfg(all(target_os = "linux", feature = "iouring"))]
+///     let r = Ok(());
+///     r
 /// }
 /// ```
 pub fn start<D, F>(future: F) -> F::Output
@@ -97,9 +100,9 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// #[cfg(not(all(target_os = "linux", feature = "iouring")))]
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     monoio::start::<monoio::LegacyDriver, _>(async {
+///     #[cfg(not(all(target_os = "linux", feature = "iouring")))]
+///     let r = monoio::start::<monoio::LegacyDriver, _>(async {
 ///         // Open a file
 ///         let file = monoio::fs::File::open("hello.txt").await?;
 ///
@@ -114,7 +117,10 @@ where
 ///         println!("{:?}", &buf[..n]);
 ///
 ///         Ok(())
-///     })
+///     });
+///     #[cfg(all(target_os = "linux", feature = "iouring"))]
+///     let r = Ok(());
+///     r
 /// }
 /// ```
 pub type BufResult<T, B> = (std::io::Result<T>, B);

--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -56,12 +56,11 @@ pub use {builder::FusionDriver, runtime::FusionRuntime};
 /// Basic usage
 ///
 /// ```no_run
-/// use monoio::fs::File;
-///
+/// #[cfg(not(all(target_os = "linux", feature = "iouring")))]
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     monoio::start::<monoio::LegacyDriver, _>(async {
 ///         // Open a file
-///         let file = File::open("hello.txt").await?;
+///         let file = monoio::fs::File::open("hello.txt").await?;
 ///
 ///         let buf = vec![0; 4096];
 ///         // Read some data, the buffer is passed by ownership and
@@ -98,12 +97,11 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// use monoio::fs::File;
-///
+/// #[cfg(not(all(target_os = "linux", feature = "iouring")))]
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     monoio::start::<monoio::LegacyDriver, _>(async {
 ///         // Open a file
-///         let file = File::open("hello.txt").await?;
+///         let file = monoio::fs::File::open("hello.txt").await?;
 ///
 ///         let buf = vec![0; 4096];
 ///         // Read some data, the buffer is passed by ownership and

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -137,7 +137,7 @@ impl TcpStream {
         let stream = TcpStream::from_shared_fd(completion.data.fd);
         // wait write ready on epoll branch
         if crate::driver::op::is_legacy() {
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            #[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "legacy"))]
             if !tfo {
                 stream.writable(true).await?;
             } else {
@@ -151,6 +151,8 @@ impl TcpStream {
                             readiness.set_writable();
                         }
                     }
+                    #[allow(unreachable_patterns)]
+                    _ => unreachable!("should never happens"),
                 })
             }
             #[cfg(not(any(target_os = "ios", target_os = "macos")))]

--- a/monoio/tests/fs_file.rs
+++ b/monoio/tests/fs_file.rs
@@ -106,11 +106,11 @@ async fn drop_open() {
 #[test]
 fn drop_off_runtime() {
     let tempfile = tempfile();
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
     let file = monoio::start::<monoio::IoUringDriver, _>(async {
         File::open(tempfile.path()).await.unwrap()
     });
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", feature = "iouring")))]
     let file = monoio::start::<monoio::LegacyDriver, _>(async {
         File::open(tempfile.path()).await.unwrap()
     });

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -31,6 +31,19 @@ macro_rules! test_connect_ip {
 
 test_connect_ip! {
     (connect_v4, "127.0.0.1:0", SocketAddr::is_ipv4),
+}
+
+#[cfg(not(all(
+    target_os = "linux",
+    any(
+        target_arch = "i686",
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv64",
+        target_arch = "s390x"
+    )
+)))]
+test_connect_ip! {
     (connect_v6, "[::1]:0", SocketAddr::is_ipv6),
 }
 

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -36,7 +36,7 @@ test_connect_ip! {
 #[cfg(not(all(
     target_os = "linux",
     any(
-        target_arch = "i686",
+        target_arch = "x86",
         target_arch = "aarch64",
         target_arch = "arm",
         target_arch = "riscv64",


### PR DESCRIPTION
It seems that there is still a lot of work to do, CI fails in many arch.

Is it correct to use `"${CARGO}" test --target "${TARGET}" --no-default-features --features "async-cancel,bytes,legacy,macros,utils" --release` for testing? @ihciah

For windows, I want to use [polling](https://crates.io/crates/polling/2.8.0) as `LegacyDriver`, it works well in my crate.