### PR TITLE
feat: make compile pass on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           OS: ${{ matrix.os }}
           PROJECT_DIR: ${{ github.workspace }}
+          NO_RUN: ${{ matrix.no_run }}
         run: sh .github/workflows/ci.sh
 
     strategy:
@@ -69,11 +70,10 @@ jobs:
           x86_64-apple-darwin,
           aarch64-apple-darwin,
 
-          # unsupported yet
-#          x86_64-pc-windows-gnu,
-#          x86_64-pc-windows-msvc,
-#          i686-pc-windows-gnu,
-#          i686-pc-windows-msvc,
+          x86_64-pc-windows-gnu,
+          x86_64-pc-windows-msvc,
+          i686-pc-windows-gnu,
+          i686-pc-windows-msvc,
         ]
         channel: [stable, nightly]
         include:
@@ -99,12 +99,15 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
 
-          # unsupported yet
-#          - target: x86_64-pc-windows-msvc
-#            os: windows-latest
-#          - target: x86_64-pc-windows-gnu
-#            os: windows-latest
-#          - target: i686-pc-windows-msvc
-#            os: windows-latest
-#          - target: i686-pc-windows-gnu
-#            os: windows-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            no_run: 1
+          - target: x86_64-pc-windows-gnu
+            os: windows-latest
+            no_run: 1
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+            no_run: 1
+          - target: i686-pc-windows-gnu
+            os: windows-latest
+            no_run: 1

--- a/monoio-macros/src/entry.rs
+++ b/monoio-macros/src/entry.rs
@@ -377,6 +377,7 @@ fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenS
     tokens
 }
 
+#[cfg(unix)]
 pub(crate) fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     // If any of the steps for this macro fail, we still want to expand to an item that is as close
     // to the expected output as possible. This helps out IDEs such that completions and other

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -24,23 +24,28 @@ memchr = "2.7"
 bytes = { version = "1", optional = true }
 flume = { version = "0.11", optional = true }
 mio = { version = "0.8", features = [
-  "net",
-  "os-poll",
-  "os-ext",
+    "net",
+    "os-poll",
+    "os-ext",
 ], optional = true }
 threadpool = { version = "1", optional = true }
 tokio = { version = "1", default-features = false, optional = true }
 tracing = { version = "0.1", default-features = false, features = [
-  "std",
+    "std",
 ], optional = true }
 ctrlc = { version = "3", optional = true }
 lazy_static = { version = "1", optional = true }
 once_cell = { version = "1.19.0", optional = true }
 
 # windows dependencies(will be added when windows support finished)
-[target.'cfg(windows)'.dependencies.windows-sys]
-features = ["Win32_Foundation", "Win32_Networking_WinSock"]
-version = "0.48.0"
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.48.0", features = [
+    "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_System_IO",
+    "Win32_Storage_FileSystem",
+    "Win32_Security"
+] }
 
 # unix dependencies
 [target.'cfg(unix)'.dependencies]

--- a/monoio/src/buf/slice.rs
+++ b/monoio/src/buf/slice.rs
@@ -310,7 +310,7 @@ unsafe impl<T: IoVecBuf> IoBuf for IoVecWrapper<T> {
         #[cfg(windows)]
         {
             let wsabuf = unsafe { *self.raw.read_wsabuf_ptr() };
-            wsabuf.len
+            wsabuf.len as _
         }
     }
 }
@@ -325,7 +325,12 @@ impl<T: IoVecBufMut> IoVecWrapperMut<T> {
     /// Create a new IoVecWrapperMut with something that impl IoVecBufMut.
     #[inline]
     pub fn new(mut iovec_buf: T) -> Result<Self, T> {
+        #[cfg(unix)]
         if iovec_buf.write_iovec_len() == 0 {
+            return Err(iovec_buf);
+        }
+        #[cfg(windows)]
+        if iovec_buf.write_wsabuf_len() == 0 {
             return Err(iovec_buf);
         }
         Ok(Self { raw: iovec_buf })
@@ -348,7 +353,7 @@ unsafe impl<T: IoVecBufMut> IoBufMut for IoVecWrapperMut<T> {
         #[cfg(windows)]
         {
             let wsabuf = unsafe { *self.raw.write_wsabuf_ptr() };
-            wsabuf.buf as *mut u8
+            wsabuf.buf
         }
     }
 
@@ -361,7 +366,7 @@ unsafe impl<T: IoVecBufMut> IoBufMut for IoVecWrapperMut<T> {
         #[cfg(windows)]
         {
             let wsabuf = unsafe { *self.raw.write_wsabuf_ptr() };
-            wsabuf.len
+            wsabuf.len as _
         }
     }
 

--- a/monoio/src/buf/vec_wrapper.rs
+++ b/monoio/src/buf/vec_wrapper.rs
@@ -1,5 +1,5 @@
 #[cfg(windows)]
-use windows_sys::Win32::Networking::WinSock::WSABUF;
+use {std::ops::Add, windows_sys::Win32::Networking::WinSock::WSABUF};
 
 use super::{IoVecBuf, IoVecBufMut};
 
@@ -44,6 +44,7 @@ pub(crate) fn read_vec_meta<T: IoVecBuf>(buf: &T) -> IoVecMeta {
             data.push(wsabuf);
             len += wsabuf.len;
         }
+        let len = len as _;
         IoVecMeta {
             data,
             offset: 0,
@@ -84,6 +85,7 @@ pub(crate) fn write_vec_meta<T: IoVecBufMut>(buf: &mut T) -> IoVecMeta {
             data.push(wsabuf);
             len += wsabuf.len;
         }
+        let len = len as _;
         IoVecMeta {
             data,
             offset: 0,
@@ -93,6 +95,7 @@ pub(crate) fn write_vec_meta<T: IoVecBufMut>(buf: &mut T) -> IoVecMeta {
 }
 
 impl IoVecMeta {
+    #[allow(unused_mut)]
     pub(crate) fn consume(&mut self, mut amt: usize) {
         #[cfg(unix)]
         {
@@ -124,6 +127,7 @@ impl IoVecMeta {
         }
         #[cfg(windows)]
         {
+            let mut amt = amt as _;
             if amt == 0 {
                 return;
             }
@@ -141,7 +145,7 @@ impl IoVecMeta {
                         return;
                     }
                     std::cmp::Ordering::Greater => {
-                        unsafe { wsabuf.len.add(amt) };
+                        _ = wsabuf.len.add(amt);
                         wsabuf.len -= amt;
                         self.offset = offset;
                         return;

--- a/monoio/src/builder.rs
+++ b/monoio/src/builder.rs
@@ -4,10 +4,11 @@ use std::{io, marker::PhantomData};
 use crate::driver::IoUringDriver;
 #[cfg(all(unix, feature = "legacy"))]
 use crate::driver::LegacyDriver;
+#[cfg(all(unix, any(feature = "legacy", feature = "iouring")))]
+use crate::utils::thread_id::gen_id;
 use crate::{
     driver::Driver,
     time::{driver::TimeDriver, Clock},
-    utils::thread_id::gen_id,
     Runtime,
 };
 

--- a/monoio/src/driver/legacy/iocp/afd.rs
+++ b/monoio/src/driver/legacy/iocp/afd.rs
@@ -67,6 +67,7 @@ pub const KNOWN_EVENTS: u32 = POLL_RECEIVE
     | POLL_CONNECT_FAIL;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct AfdPollHandleInfo {
     pub handle: HANDLE,
     pub events: u32,
@@ -74,6 +75,7 @@ pub struct AfdPollHandleInfo {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct AfdPollInfo {
     pub timeout: i64,
     pub number_of_handles: u32,
@@ -81,6 +83,7 @@ pub struct AfdPollInfo {
     pub handles: [AfdPollHandleInfo; 1],
 }
 
+#[derive(Debug)]
 pub struct Afd {
     file: File,
 }

--- a/monoio/src/driver/legacy/iocp/core.rs
+++ b/monoio/src/driver/legacy/iocp/core.rs
@@ -31,7 +31,7 @@ impl CompletionPort {
         let result = unsafe { CreateIoCompletionPort(handle, self.handle, token, 0) };
 
         if result == 0 {
-            return Err(std::io::Error::last_os_error());
+            Err(std::io::Error::last_os_error())
         } else {
             Ok(())
         }

--- a/monoio/src/driver/legacy/iocp/mod.rs
+++ b/monoio/src/driver/legacy/iocp/mod.rs
@@ -1,9 +1,10 @@
 mod afd;
+mod core;
 mod event;
-mod iocp;
 mod state;
 mod waker;
 
+pub use core::*;
 use std::{
     collections::VecDeque,
     os::windows::prelude::RawSocket,
@@ -17,7 +18,6 @@ use std::{
 
 pub use afd::*;
 pub use event::*;
-pub use iocp::*;
 pub use state::*;
 pub use waker::*;
 use windows_sys::Win32::{

--- a/monoio/src/driver/legacy/iocp/state.rs
+++ b/monoio/src/driver/legacy/iocp/state.rs
@@ -1,3 +1,4 @@
+use core::fmt::Debug;
 use std::{
     marker::PhantomPinned,
     os::windows::prelude::RawSocket,
@@ -23,6 +24,7 @@ pub enum SockPollStatus {
     Cancelled,
 }
 
+#[derive(Debug)]
 pub struct SocketState {
     pub socket: RawSocket,
     pub inner: Option<Pin<Arc<Mutex<SockState>>>>,
@@ -220,6 +222,13 @@ impl SockState {
         self.poll_status = SockPollStatus::Cancelled;
         self.pending_evts = 0;
         Ok(())
+    }
+}
+
+impl Debug for SockState {
+    #[allow(unused_variables)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
     }
 }
 

--- a/monoio/src/driver/legacy/iocp/waker.rs
+++ b/monoio/src/driver/legacy/iocp/waker.rs
@@ -9,17 +9,18 @@ pub struct Waker {
 }
 
 impl Waker {
+    #[allow(unreachable_code, unused_variables)]
     pub fn new(poller: &Poller, token: mio::Token) -> io::Result<Waker> {
         Ok(Waker {
             token,
-            port: poller.cp.clone(),
+            // port: poller.cp.clone(),
+            port: unimplemented!(),
         })
     }
 
     pub fn wake(&self) -> io::Result<()> {
         let mut ev = Event::new(self.token);
         ev.set_readable();
-
-        self.port.post(ev.to_completion_status())
+        self.port.post(ev.to_entry())
     }
 }

--- a/monoio/src/driver/legacy/mod.rs
+++ b/monoio/src/driver/legacy/mod.rs
@@ -16,6 +16,7 @@ use super::{
 };
 use crate::utils::slab::Slab;
 
+#[allow(missing_docs, unreachable_pub, dead_code, unused_imports)]
 #[cfg(windows)]
 pub(super) mod iocp;
 
@@ -44,6 +45,7 @@ pub(crate) struct LegacyInner {
 }
 
 /// Driver with Poll-like syscall.
+#[allow(unreachable_pub)]
 pub struct LegacyDriver {
     inner: Rc<UnsafeCell<LegacyInner>>,
 
@@ -55,6 +57,7 @@ pub struct LegacyDriver {
 #[cfg(feature = "sync")]
 const TOKEN_WAKEUP: mio::Token = mio::Token(1 << 31);
 
+#[allow(dead_code)]
 impl LegacyDriver {
     const DEFAULT_ENTRIES: u32 = 1024;
 
@@ -154,7 +157,11 @@ impl LegacyDriver {
             Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
             Err(e) => return Err(e),
         }
-        for event in events.iter() {
+        #[cfg(unix)]
+        let iter = events.iter();
+        #[cfg(windows)]
+        let iter = events.events.iter();
+        for event in iter {
             let token = event.token();
 
             #[cfg(feature = "sync")]
@@ -171,7 +178,7 @@ impl LegacyDriver {
     #[cfg(windows)]
     pub(crate) fn register(
         this: &Rc<UnsafeCell<LegacyInner>>,
-        state: &mut iocp::SockState,
+        state: &mut iocp::SocketState,
         interest: mio::Interest,
     ) -> io::Result<usize> {
         let inner = unsafe { &mut *this.get() };
@@ -191,7 +198,7 @@ impl LegacyDriver {
     pub(crate) fn deregister(
         this: &Rc<UnsafeCell<LegacyInner>>,
         token: usize,
-        state: &mut iocp::SockState,
+        state: &mut iocp::SocketState,
     ) -> io::Result<()> {
         let inner = unsafe { &mut *this.get() };
 

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -1,4 +1,5 @@
 /// Monoio Driver.
+#[allow(dead_code)]
 pub(crate) mod op;
 #[cfg(feature = "poll-io")]
 pub(crate) mod poll;
@@ -6,6 +7,7 @@ pub(crate) mod poll;
 pub(crate) mod ready;
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
 pub(crate) mod scheduled_io;
+#[allow(dead_code)]
 pub(crate) mod shared_fd;
 #[cfg(feature = "sync")]
 pub(crate) mod thread;
@@ -23,7 +25,8 @@ use std::{
     time::Duration,
 };
 
-#[cfg(feature = "legacy")]
+#[allow(unreachable_pub)]
+#[cfg(all(feature = "legacy", unix))]
 pub use self::legacy::LegacyDriver;
 #[cfg(feature = "legacy")]
 use self::legacy::LegacyInner;
@@ -96,8 +99,6 @@ pub(crate) enum Inner {
 impl Inner {
     fn submit_with<T: OpAble>(&self, data: T) -> io::Result<Op<T>> {
         match self {
-            #[cfg(windows)]
-            _ => unimplemented!(),
             #[cfg(all(target_os = "linux", feature = "iouring"))]
             Inner::Uring(this) => UringInner::submit_with_data(this, data),
             #[cfg(feature = "legacy")]
@@ -107,7 +108,10 @@ impl Inner {
                 not(all(target_os = "linux", feature = "iouring"))
             ))]
             _ => {
+                #[cfg(unix)]
                 util::feature_panic();
+                #[cfg(windows)]
+                unimplemented!();
             }
         }
     }

--- a/monoio/src/driver/op.rs
+++ b/monoio/src/driver/op.rs
@@ -61,6 +61,7 @@ pub(crate) trait OpAble {
 
 /// If legacy is enabled and iouring is not, we can expose io interface in a poll-like way.
 /// This can provide better compatibility for crates programmed in poll-like way.
+#[allow(dead_code)]
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
 pub(crate) trait PollLegacy {
     #[cfg(feature = "legacy")]

--- a/monoio/src/driver/op/accept.rs
+++ b/monoio/src/driver/op/accept.rs
@@ -1,3 +1,5 @@
+#[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
+use std::os::unix::prelude::AsRawFd;
 use std::{
     io,
     mem::{size_of, MaybeUninit},
@@ -13,12 +15,12 @@ use {
         accept, socklen_t, INVALID_SOCKET, SOCKADDR_STORAGE,
     },
 };
-#[cfg(any(feature = "legacy", feature = "poll-io"))]
-use {crate::syscall_u32, std::os::unix::prelude::AsRawFd};
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
 use crate::driver::ready::Direction;
+#[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
+use crate::syscall_u32;
 
 /// Accept
 pub(crate) struct Accept {
@@ -62,7 +64,7 @@ impl OpAble for Accept {
         .build()
     }
 
-    #[cfg(all(any(feature = "legacy", feature = "poll-io"), not(windows)))]
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
     #[inline]
     fn legacy_interest(&self) -> Option<(Direction, usize)> {
         self.fd.registered_index().map(|idx| (Direction::Read, idx))
@@ -74,10 +76,10 @@ impl OpAble for Accept {
         let addr = self.addr.0.as_mut_ptr() as *mut _;
         let len = &mut self.addr.1;
 
-        syscall!(accept(fd, addr, len), PartialEq::eq, INVALID_SOCKET)
+        syscall!(accept(fd as _, addr, len), PartialEq::eq, INVALID_SOCKET)
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<u32> {
         let fd = self.fd.as_raw_fd();
         let addr = self.addr.0.as_mut_ptr() as *mut _;

--- a/monoio/src/driver/op/close.rs
+++ b/monoio/src/driver/op/close.rs
@@ -50,6 +50,6 @@ impl OpAble for Close {
         return crate::syscall_u32!(close(self.fd));
 
         #[cfg(windows)]
-        return syscall!(closesocket(self.fd), PartialEq::ne, 0);
+        return syscall!(closesocket(self.fd as _), PartialEq::ne, 0);
     }
 }

--- a/monoio/src/driver/op/open.rs
+++ b/monoio/src/driver/op/open.rs
@@ -10,7 +10,7 @@ use super::{Op, OpAble};
 use crate::driver::ready::Direction;
 #[cfg(windows)]
 use crate::syscall;
-#[cfg(any(feature = "legacy", feature = "poll-io"))]
+#[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
 use crate::syscall_u32;
 use crate::{driver::util::cstr, fs::OpenOptions};
 
@@ -81,13 +81,13 @@ impl OpAble for Open {
     fn legacy_call(&mut self) -> io::Result<u32> {
         syscall!(
             CreateFileW(
-                self.path.as_c_str().as_ptr(),
+                self.path.as_c_str().as_ptr().cast(),
                 self.opts.access_mode()?,
                 self.opts.share_mode,
                 self.opts.security_attributes,
                 self.opts.creation_mode()?,
                 self.opts.get_flags_and_attributes(),
-                std::ptr::null_mut(),
+                0,
             ),
             PartialEq::eq,
             INVALID_HANDLE_VALUE

--- a/monoio/src/driver/op/poll.rs
+++ b/monoio/src/driver/op/poll.rs
@@ -107,7 +107,7 @@ impl OpAble for PollAdd {
     fn legacy_call(&mut self) -> io::Result<u32> {
         if !self.relaxed {
             let mut pollfd = WSAPOLLFD {
-                fd: self.fd.as_raw_socket(),
+                fd: self.fd.as_raw_socket() as _,
                 events: if self.is_read {
                     POLLIN as _
                 } else {

--- a/monoio/src/driver/op/recv.rs
+++ b/monoio/src/driver/op/recv.rs
@@ -1,19 +1,26 @@
-use std::{
-    io,
-    mem::{transmute, MaybeUninit},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
-};
+use std::{io, net::SocketAddr};
 
 #[cfg(all(target_os = "linux", feature = "iouring"))]
 use io_uring::{opcode, types};
-#[cfg(any(feature = "legacy", feature = "poll-io"))]
+#[cfg(unix)]
 use {
-    crate::{driver::ready::Direction, syscall_u32},
-    std::os::unix::prelude::AsRawFd,
+    crate::net::unix::SocketAddr as UnixSocketAddr,
+    libc::{socklen_t, AF_INET, AF_INET6},
+    std::mem::{transmute, MaybeUninit},
+    std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
 };
+#[cfg(all(windows, any(feature = "legacy", feature = "poll-io")))]
+use {
+    crate::syscall, std::os::windows::io::AsRawSocket,
+    windows_sys::Win32::Networking::WinSock::recv,
+};
+#[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
+use {crate::syscall_u32, std::os::unix::prelude::AsRawFd};
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
-use crate::{buf::IoBufMut, net::unix::SocketAddr as UnixSocketAddr, BufResult};
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use crate::driver::ready::Direction;
+use crate::{buf::IoBufMut, BufResult};
 
 pub(crate) struct Recv<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -70,7 +77,7 @@ impl<T: IoBufMut> OpAble for Recv<T> {
         self.fd.registered_index().map(|idx| (Direction::Read, idx))
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<u32> {
         let fd = self.fd.as_raw_fd();
         syscall_u32!(recv(
@@ -79,6 +86,21 @@ impl<T: IoBufMut> OpAble for Recv<T> {
             self.buf.bytes_total().min(u32::MAX as usize),
             0
         ))
+    }
+
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        let fd = self.fd.as_raw_socket();
+        syscall!(
+            recv(
+                fd as _,
+                self.buf.write_ptr(),
+                self.buf.bytes_total() as _,
+                0
+            ),
+            PartialOrd::ge,
+            0
+        )
     }
 }
 
@@ -90,6 +112,7 @@ pub(crate) struct RecvMsg<T> {
 
     /// Reference to the in-flight buffer.
     pub(crate) buf: T,
+    #[cfg(unix)]
     pub(crate) info: Box<(
         MaybeUninit<libc::sockaddr_storage>,
         [libc::iovec; 1],
@@ -97,6 +120,7 @@ pub(crate) struct RecvMsg<T> {
     )>,
 }
 
+#[cfg(unix)]
 impl<T: IoBufMut> Op<RecvMsg<T>> {
     pub(crate) fn recv_msg(fd: SharedFd, mut buf: T) -> io::Result<Self> {
         let iovec = [libc::iovec {
@@ -112,7 +136,7 @@ impl<T: IoBufMut> Op<RecvMsg<T>> {
         info.2.msg_iov = info.1.as_mut_ptr();
         info.2.msg_iovlen = 1;
         info.2.msg_name = &mut info.0 as *mut _ as *mut libc::c_void;
-        info.2.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+        info.2.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as socklen_t;
 
         Op::submit_with(RecvMsg { fd, buf, info })
     }
@@ -127,7 +151,7 @@ impl<T: IoBufMut> Op<RecvMsg<T>> {
 
             let addr = unsafe {
                 match storage.ss_family as libc::c_int {
-                    libc::AF_INET => {
+                    AF_INET => {
                         // Safety: if the ss_family field is AF_INET then storage must be a
                         // sockaddr_in.
                         let addr: &libc::sockaddr_in = transmute(&storage);
@@ -135,7 +159,7 @@ impl<T: IoBufMut> Op<RecvMsg<T>> {
                         let port = u16::from_be(addr.sin_port);
                         SocketAddr::V4(SocketAddrV4::new(ip, port))
                     }
-                    libc::AF_INET6 => {
+                    AF_INET6 => {
                         // Safety: if the ss_family field is AF_INET6 then storage must be a
                         // sockaddr_in6.
                         let addr: &libc::sockaddr_in6 = transmute(&storage);
@@ -165,6 +189,18 @@ impl<T: IoBufMut> Op<RecvMsg<T>> {
     }
 }
 
+#[cfg(windows)]
+impl<T: IoBufMut> Op<RecvMsg<T>> {
+    #[allow(unused_mut, unused_variables)]
+    pub(crate) fn recv_msg(fd: SharedFd, mut buf: T) -> io::Result<Self> {
+        unimplemented!()
+    }
+
+    pub(crate) async fn wait(self) -> BufResult<(usize, SocketAddr), T> {
+        unimplemented!()
+    }
+}
+
 impl<T: IoBufMut> OpAble for RecvMsg<T> {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
@@ -177,10 +213,16 @@ impl<T: IoBufMut> OpAble for RecvMsg<T> {
         self.fd.registered_index().map(|idx| (Direction::Read, idx))
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<u32> {
         let fd = self.fd.as_raw_fd();
         syscall_u32!(recvmsg(fd, &mut self.info.2 as *mut _, 0))
+    }
+
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        let _fd = self.fd.as_raw_socket();
+        unimplemented!();
     }
 }
 
@@ -192,6 +234,7 @@ pub(crate) struct RecvMsgUnix<T> {
 
     /// Reference to the in-flight buffer.
     pub(crate) buf: T,
+    #[cfg(unix)]
     pub(crate) info: Box<(
         MaybeUninit<libc::sockaddr_storage>,
         [libc::iovec; 1],
@@ -199,6 +242,7 @@ pub(crate) struct RecvMsgUnix<T> {
     )>,
 }
 
+#[cfg(unix)]
 impl<T: IoBufMut> Op<RecvMsgUnix<T>> {
     pub(crate) fn recv_msg_unix(fd: SharedFd, mut buf: T) -> io::Result<Self> {
         let iovec = [libc::iovec {
@@ -214,7 +258,7 @@ impl<T: IoBufMut> Op<RecvMsgUnix<T>> {
         info.2.msg_iov = info.1.as_mut_ptr();
         info.2.msg_iovlen = 1;
         info.2.msg_name = &mut info.0 as *mut _ as *mut libc::c_void;
-        info.2.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+        info.2.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as socklen_t;
 
         Op::submit_with(RecvMsgUnix { fd, buf, info })
     }
@@ -244,6 +288,18 @@ impl<T: IoBufMut> Op<RecvMsgUnix<T>> {
     }
 }
 
+#[cfg(windows)]
+impl<T: IoBufMut> Op<RecvMsgUnix<T>> {
+    #[allow(unused_mut, unused_variables)]
+    pub(crate) fn recv_msg_unix(fd: SharedFd, mut buf: T) -> io::Result<Self> {
+        unimplemented!()
+    }
+
+    pub(crate) async fn wait(self) -> BufResult<(usize, SocketAddr), T> {
+        unimplemented!()
+    }
+}
+
 impl<T: IoBufMut> OpAble for RecvMsgUnix<T> {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
@@ -256,9 +312,15 @@ impl<T: IoBufMut> OpAble for RecvMsgUnix<T> {
         self.fd.registered_index().map(|idx| (Direction::Read, idx))
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<u32> {
         let fd = self.fd.as_raw_fd();
         syscall_u32!(recvmsg(fd, &mut self.info.2 as *mut _, 0))
+    }
+
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        let _fd = self.fd.as_raw_socket();
+        unimplemented!();
     }
 }

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -2,15 +2,20 @@ use std::{io, net::SocketAddr};
 
 #[cfg(all(target_os = "linux", feature = "iouring"))]
 use io_uring::{opcode, types};
-use socket2::SockAddr;
-#[cfg(any(feature = "legacy", feature = "poll-io"))]
+#[cfg(unix)]
+use {crate::net::unix::SocketAddr as UnixSocketAddr, socket2::SockAddr};
+#[cfg(all(windows, any(feature = "legacy", feature = "poll-io")))]
 use {
-    crate::{driver::ready::Direction, syscall_u32},
-    std::os::unix::prelude::AsRawFd,
+    crate::syscall, std::os::windows::io::AsRawSocket,
+    windows_sys::Win32::Networking::WinSock::send,
 };
+#[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
+use {crate::syscall_u32, std::os::unix::prelude::AsRawFd};
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
-use crate::{buf::IoBuf, net::unix::SocketAddr as UnixSocketAddr, BufResult};
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use crate::driver::ready::Direction;
+use crate::{buf::IoBuf, BufResult};
 
 pub(crate) struct Send<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -82,7 +87,7 @@ impl<T: IoBuf> OpAble for Send<T> {
             .map(|idx| (Direction::Write, idx))
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<u32> {
         let fd = self.fd.as_raw_fd();
         #[cfg(target_os = "linux")]
@@ -98,6 +103,16 @@ impl<T: IoBuf> OpAble for Send<T> {
             flags
         ))
     }
+
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        let fd = self.fd.as_raw_socket();
+        syscall!(
+            send(fd as _, self.buf.read_ptr(), self.buf.bytes_init() as _, 0),
+            PartialOrd::ge,
+            0
+        )
+    }
 }
 
 pub(crate) struct SendMsg<T> {
@@ -108,9 +123,11 @@ pub(crate) struct SendMsg<T> {
 
     /// Reference to the in-flight buffer.
     pub(crate) buf: T,
+    #[cfg(unix)]
     pub(crate) info: Box<(Option<SockAddr>, [libc::iovec; 1], libc::msghdr)>,
 }
 
+#[cfg(unix)]
 impl<T: IoBuf> Op<SendMsg<T>> {
     pub(crate) fn send_msg(
         fd: SharedFd,
@@ -151,6 +168,22 @@ impl<T: IoBuf> Op<SendMsg<T>> {
     }
 }
 
+#[cfg(windows)]
+impl<T: IoBuf> Op<SendMsg<T>> {
+    #[allow(unused_variables)]
+    pub(crate) fn send_msg(
+        fd: SharedFd,
+        buf: T,
+        socket_addr: Option<SocketAddr>,
+    ) -> io::Result<Self> {
+        unimplemented!()
+    }
+
+    pub(crate) async fn wait(self) -> BufResult<usize, T> {
+        unimplemented!()
+    }
+}
+
 impl<T: IoBuf> OpAble for SendMsg<T> {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
@@ -169,7 +202,7 @@ impl<T: IoBuf> OpAble for SendMsg<T> {
             .map(|idx| (Direction::Write, idx))
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<u32> {
         #[cfg(target_os = "linux")]
         #[allow(deprecated)]
@@ -178,6 +211,12 @@ impl<T: IoBuf> OpAble for SendMsg<T> {
         const FLAGS: libc::c_int = 0;
         let fd = self.fd.as_raw_fd();
         syscall_u32!(sendmsg(fd, &mut self.info.2 as *mut _, FLAGS))
+    }
+
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        let _fd = self.fd.as_raw_socket();
+        unimplemented!();
     }
 }
 
@@ -189,9 +228,11 @@ pub(crate) struct SendMsgUnix<T> {
 
     /// Reference to the in-flight buffer.
     pub(crate) buf: T,
+    #[cfg(unix)]
     pub(crate) info: Box<(Option<UnixSocketAddr>, [libc::iovec; 1], libc::msghdr)>,
 }
 
+#[cfg(unix)]
 impl<T: IoBuf> Op<SendMsgUnix<T>> {
     pub(crate) fn send_msg_unix(
         fd: SharedFd,
@@ -232,6 +273,22 @@ impl<T: IoBuf> Op<SendMsgUnix<T>> {
     }
 }
 
+#[cfg(windows)]
+impl<T: IoBuf> Op<SendMsgUnix<T>> {
+    #[allow(unused_variables)]
+    pub(crate) fn send_msg_unix(
+        fd: SharedFd,
+        buf: T,
+        socket_addr: Option<SocketAddr>,
+    ) -> io::Result<Self> {
+        unimplemented!()
+    }
+
+    pub(crate) async fn wait(self) -> BufResult<usize, T> {
+        unimplemented!()
+    }
+}
+
 impl<T: IoBuf> OpAble for SendMsgUnix<T> {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
@@ -250,7 +307,7 @@ impl<T: IoBuf> OpAble for SendMsgUnix<T> {
             .map(|idx| (Direction::Write, idx))
     }
 
-    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     #[inline]
     fn legacy_call(&mut self) -> io::Result<u32> {
         #[cfg(target_os = "linux")]
@@ -260,5 +317,11 @@ impl<T: IoBuf> OpAble for SendMsgUnix<T> {
         const FLAGS: libc::c_int = 0;
         let fd = self.fd.as_raw_fd();
         syscall_u32!(sendmsg(fd, &mut self.info.2 as *mut _, FLAGS))
+    }
+
+    #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        let _fd = self.fd.as_raw_socket();
+        unimplemented!();
     }
 }

--- a/monoio/src/driver/ready.rs
+++ b/monoio/src/driver/ready.rs
@@ -46,7 +46,7 @@ impl Ready {
     pub(crate) const WRITE_ALL: Ready = Ready(WRITABLE | WRITE_CLOSED | WRITE_CANCELED);
 
     #[cfg(windows)]
-    pub(crate) fn from_mio(event: &super::iocp::Event) -> Ready {
+    pub(crate) fn from_mio(event: &super::legacy::iocp::Event) -> Ready {
         let mut ready = Ready::EMPTY;
 
         if event.is_readable() {
@@ -242,4 +242,5 @@ impl Direction {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) const RW_INTERESTS: mio::Interest = mio::Interest::READABLE.add(mio::Interest::WRITABLE);

--- a/monoio/src/driver/util.rs
+++ b/monoio/src/driver/util.rs
@@ -1,5 +1,6 @@
 use std::{ffi::CString, io, path::Path};
 
+#[allow(unused_variables)]
 pub(super) fn cstr(p: &Path) -> io::Result<CString> {
     #[cfg(unix)]
     {
@@ -35,6 +36,7 @@ macro_rules! syscall {
     }};
 }
 
+/// Do syscall and return Result<T, std::io::Error>
 #[cfg(windows)]
 #[macro_export]
 macro_rules! syscall {
@@ -43,7 +45,7 @@ macro_rules! syscall {
         if $err_test(&res, &$err_value) {
             Err(io::Error::last_os_error())
         } else {
-            Ok(res)
+            Ok(res.try_into().unwrap())
         }
     }};
 }

--- a/monoio/src/fs/file.rs
+++ b/monoio/src/fs/file.rs
@@ -1,11 +1,14 @@
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, RawHandle};
 #[cfg(unix)]
-use std::os::{
-    fd::IntoRawFd,
-    unix::io::{AsRawFd, RawFd},
+use std::{
+    fs::File as StdFile,
+    os::{
+        fd::IntoRawFd,
+        unix::io::{AsRawFd, RawFd},
+    },
 };
-use std::{fs::File as StdFile, io, path::Path};
+use std::{io, path::Path};
 
 use crate::{
     buf::{IoBuf, IoBufMut},

--- a/monoio/src/fs/open_options.rs
+++ b/monoio/src/fs/open_options.rs
@@ -378,7 +378,7 @@ impl OpenOptions {
             (false, _, true, None) => Ok(FILE_GENERIC_WRITE & !FILE_WRITE_DATA),
             (true, _, true, None) => Ok(GENERIC_READ | (FILE_GENERIC_WRITE & !FILE_WRITE_DATA)),
             (false, false, false, None) => {
-                Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER))
+                Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as _))
             }
         }
     }
@@ -414,12 +414,12 @@ impl OpenOptions {
             (true, false) => {}
             (false, false) => {
                 if self.truncate || self.create || self.create_new {
-                    return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER));
+                    return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as _));
                 }
             }
             (_, true) => {
                 if self.truncate && !self.create_new {
-                    return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER));
+                    return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as _));
                 }
             }
         }
@@ -439,7 +439,7 @@ impl OpenOptions {
             | self.attributes
             | self.security_qos_flags
             | if self.create_new {
-                FILE_FLAG_OPEN_REPARSE_POINT
+                FILE_FLAG_OPEN_REPARSE_POINT as _
             } else {
                 0
             }

--- a/monoio/src/io/async_buf_read_ext.rs
+++ b/monoio/src/io/async_buf_read_ext.rs
@@ -1,7 +1,6 @@
 use std::{
     future::Future,
     io::{Error, ErrorKind, Result},
-    ops::Drop,
     str::from_utf8,
 };
 

--- a/monoio/src/io/util/copy.rs
+++ b/monoio/src/io/util/copy.rs
@@ -2,10 +2,9 @@
 
 use std::io;
 
-use crate::{
-    io::{AsyncReadRent, AsyncWriteRent, AsyncWriteRentExt},
-    net::unix::new_pipe,
-};
+use crate::io::{AsyncReadRent, AsyncWriteRent, AsyncWriteRentExt};
+#[cfg(unix)]
+use crate::net::unix::new_pipe;
 
 const BUF_SIZE: usize = 4 * 1024;
 

--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -14,6 +14,7 @@ pub use monoio_macros::select_priv_declare_output_enum;
 #[macro_use]
 mod driver;
 pub(crate) mod builder;
+#[allow(dead_code)]
 pub(crate) mod runtime;
 mod scheduler;
 pub mod time;

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -1,6 +1,9 @@
 use std::future::Future;
 
-#[cfg(any(all(target_os = "linux", feature = "iouring"), feature = "legacy"))]
+#[cfg(all(
+    unix,
+    any(all(target_os = "linux", feature = "iouring"), feature = "legacy")
+))]
 use crate::time::TimeDriver;
 #[cfg(all(target_os = "linux", feature = "iouring"))]
 use crate::IoUringDriver;

--- a/monoio/src/time/driver/mod.rs
+++ b/monoio/src/time/driver/mod.rs
@@ -1,7 +1,7 @@
 // Currently, rust warns when an unsafe fn contains an unsafe {} block. However,
 // in the future, this will change to the reverse. For now, suppress this
 // warning and generally stick with being explicit about unsafety.
-#![allow(unused_unsafe)]
+#![allow(unused_unsafe, unused_imports)]
 #![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 //! Time driver

--- a/monoio/src/time/driver/mod.rs
+++ b/monoio/src/time/driver/mod.rs
@@ -1,7 +1,7 @@
 // Currently, rust warns when an unsafe fn contains an unsafe {} block. However,
 // in the future, this will change to the reverse. For now, suppress this
 // warning and generally stick with being explicit about unsafety.
-#![allow(unused_unsafe, unused_imports)]
+#![allow(unused_unsafe)]
 #![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 //! Time driver
@@ -16,7 +16,7 @@ mod wheel;
 
 pub(super) mod sleep;
 
-use std::{cell::RefCell, convert::TryInto, fmt, io, num::NonZeroU64, ptr::NonNull, rc::Rc};
+use std::{cell::RefCell, fmt, io, num::NonZeroU64, ptr::NonNull, rc::Rc};
 
 use crate::{
     driver::Driver,

--- a/monoio/src/time/interval.rs
+++ b/monoio/src/time/interval.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryInto,
     future::Future,
     pin::Pin,
     task::{Context, Poll},

--- a/monoio/src/utils/bind_to_cpu_set.rs
+++ b/monoio/src/utils/bind_to_cpu_set.rs
@@ -2,6 +2,7 @@
 #[cfg(unix)]
 pub type BindError<T> = nix::Result<T>;
 
+/// Bind error
 #[cfg(windows)]
 pub type BindError<T> = std::io::Result<T>;
 
@@ -25,6 +26,7 @@ pub fn bind_to_cpu_set(_: impl IntoIterator<Item = usize>) -> BindError<()> {
     Ok(())
 }
 
+/// Bind current thread to given cpus
 #[cfg(windows)]
 pub fn bind_to_cpu_set(_: impl IntoIterator<Item = usize>) -> BindError<()> {
     Ok(())

--- a/monoio/src/utils/mod.rs
+++ b/monoio/src/utils/mod.rs
@@ -2,7 +2,9 @@
 
 pub(crate) mod box_into_inner;
 pub(crate) mod linked_list;
+#[allow(dead_code)]
 pub(crate) mod slab;
+#[allow(dead_code)]
 pub(crate) mod thread_id;
 pub(crate) mod uring_detect;
 


### PR DESCRIPTION
Simply supporting compilation on Windows is already a huge workload. This PR solves most compilation errors, and I found that the `buf` module is missing `msg`. Do you plan to manually assemble `libc::msghdr`/`windows_sys::Win32::Networking::WinSock::WSAMSG` directly? @ihciah 