### PR TITLE
Fix docs.rs build

### DIFF
--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, unreachable_pub)]
 #![allow(stable_features)]
 #![cfg_attr(feature = "unstable", feature(io_error_more))]


### PR DESCRIPTION
Currently, we can't jump docs from https://crates.io/crates/monoio because of the build error on https://docs.rs/crate/monoio/0.2.3/builds/1164346

This PR fixes it.

I've checked these 2 commands below.

```
cargo +nightly --config "build.rustdocflags=[\"--cfg\", \"docsrs\"]" doc

... fine
```

```
cargo doc

... fine
```