### PR TITLE
fix: don't register file fd in `File::from_std`

### DIFF
--- a/monoio/src/fs/file.rs
+++ b/monoio/src/fs/file.rs
@@ -142,7 +142,7 @@ impl File {
     #[cfg(unix)]
     pub fn from_std(std: StdFile) -> io::Result<File> {
         Ok(File {
-            fd: SharedFd::new::<false>(std.into_raw_fd())?,
+            fd: SharedFd::new_without_register(std.into_raw_fd()),
         })
     }
 

--- a/monoio/tests/fs_file.rs
+++ b/monoio/tests/fs_file.rs
@@ -193,3 +193,18 @@ fn assert_invalid_fd(fd: RawFd, base: std::fs::Metadata) {
         }
     }
 }
+
+#[monoio::test_all]
+async fn file_from_std() {
+    let tempfile = tempfile();
+    let std_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(tempfile.path())
+        .unwrap();
+    let file = File::from_std(std_file).unwrap();
+    file.write_at(HELLO, 0).await.0.unwrap();
+    file.sync_all().await.unwrap();
+    read_hello(&file).await;
+}


### PR DESCRIPTION
Closes #276. Also adds a unit test.