### PR TITLE
feat: Define monoio MSRV to 1.80

### DIFF
--- a/monoio-compat/Cargo.toml
+++ b/monoio-compat/Cargo.toml
@@ -9,6 +9,7 @@ name = "monoio-compat"
 readme = "README.md"
 repository = "https://github.com/bytedance/monoio"
 version = "0.2.2"
+rust-version = "1.80"
 
 [dependencies]
 monoio = { version = "0.2.3", path = "../monoio", default-features = false, features = ["legacy"] }

--- a/monoio-compat/src/lib.rs
+++ b/monoio-compat/src/lib.rs
@@ -1,7 +1,5 @@
 //! For compat with tokio AsyncRead and AsyncWrite.
 
-#![cfg_attr(feature = "unstable", feature(new_uninit))]
-
 pub mod box_future;
 mod buf;
 

--- a/monoio-macros/Cargo.toml
+++ b/monoio-macros/Cargo.toml
@@ -9,6 +9,7 @@ name = "monoio-macros"
 readme = "README.md"
 repository = "https://github.com/bytedance/monoio"
 version = "0.1.0"
+rust-version = "1.80"
 
 [lib]
 proc-macro = true

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -9,6 +9,7 @@ name = "monoio"
 readme = "../README.md"
 repository = "https://github.com/bytedance/monoio"
 version = "0.2.3"
+rust-version = "1.80"
 
 # common dependencies
 [dependencies]
@@ -61,6 +62,8 @@ tempfile = "3.2"
 
 [features]
 # use nightly only feature flags
+#
+# This feature has been deprecated and will be removed in the future.
 unstable = []
 # async-cancel will push a async-cancel entry into sq when op is canceled
 async-cancel = []

--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -400,13 +400,6 @@ impl UringInner {
     fn submit(&mut self) -> io::Result<()> {
         loop {
             match self.uring.submit() {
-                #[cfg(feature = "unstable")]
-                Err(ref e)
-                    if matches!(e.kind(), io::ErrorKind::Other | io::ErrorKind::ResourceBusy) =>
-                {
-                    self.tick()?;
-                }
-                #[cfg(not(feature = "unstable"))]
                 Err(ref e)
                     if matches!(e.raw_os_error(), Some(libc::EAGAIN) | Some(libc::EBUSY)) =>
                 {

--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -1,12 +1,7 @@
 #![doc = include_str!("../../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, unreachable_pub)]
-#![allow(stable_features)]
 #![allow(clippy::macro_metavars_in_unsafe)]
-#![cfg_attr(feature = "unstable", feature(io_error_more))]
-#![cfg_attr(feature = "unstable", feature(lazy_cell))]
-#![cfg_attr(feature = "unstable", feature(stmt_expr_attributes))]
-#![cfg_attr(feature = "unstable", feature(thread_local))]
 
 #[macro_use]
 pub mod macros;

--- a/monoio/src/net/tcp/tfo/linux.rs
+++ b/monoio/src/net/tcp/tfo/linux.rs
@@ -1,10 +1,5 @@
 use std::{cell::Cell, io, os::fd::AsRawFd};
 
-#[cfg(feature = "unstable")]
-#[thread_local]
-pub(crate) static TFO_CONNECT_AVAILABLE: Cell<bool> = Cell::new(true);
-
-#[cfg(not(feature = "unstable"))]
 thread_local! {
     pub(crate) static TFO_CONNECT_AVAILABLE: Cell<bool> = const { Cell::new(true) };
 }

--- a/monoio/src/task/waker_fn.rs
+++ b/monoio/src/task/waker_fn.rs
@@ -27,11 +27,6 @@ pub(crate) fn dummy_waker() -> Waker {
     unsafe { Waker::from_raw(raw_waker()) }
 }
 
-#[cfg(feature = "unstable")]
-#[thread_local]
-static SHOULD_POLL: Cell<bool> = Cell::new(true);
-
-#[cfg(not(feature = "unstable"))]
 thread_local! {
     static SHOULD_POLL: Cell<bool> = const { Cell::new(true) };
 }


### PR DESCRIPTION
This PR marks monoio available in stable rust.

We deprecated the `unstable` feature because most of the functionalities we need are now stable or have alternatives. Developing Monoio on stable Rust will allow a broader ecosystem to explore and use Monoio. This change will also reduce the burden on our maintainers.