### PR TITLE
ci: using main branch of cross

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -9,8 +9,10 @@ if [ "${NO_RUN}" != "1" ] && [ "${NO_RUN}" != "true" ]; then
         export CARGO_NET_RETRY=5
         export CARGO_NET_TIMEOUT=10
 
-        cargo install cross
+        cargo install cross --git "https://github.com/cross-rs/cross" --rev "7b79041c9278769eca57fae10c74741f5aa5c14b"
         CARGO=cross
+
+        cargo clean
     fi
 
     # If a test crashes, we want to know which one it was.
@@ -31,13 +33,13 @@ if [ "${NO_RUN}" != "1" ] && [ "${NO_RUN}" != "true" ]; then
     fi
 
     if [ "${TARGET}" != "aarch64-unknown-linux-gnu" ] && [ "${TARGET}" != "armv7-unknown-linux-gnueabihf" ] &&
-       [ "${TARGET}" != "riscv64gc-unknown-linux-gnu" ] && [ "${TARGET}" != "s390x-unknown-linux-gnu" ]; then
+        [ "${TARGET}" != "riscv64gc-unknown-linux-gnu" ] && [ "${TARGET}" != "s390x-unknown-linux-gnu" ]; then
         # enable uring+legacy driver
         "${CARGO}" test --target "${TARGET}"
         "${CARGO}" test --target "${TARGET}" --release
     fi
 
-    if [ "${CHANNEL}" == "nightly" ] && ( [ "${TARGET}" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "i686-unknown-linux-gnu" ] ); then
+    if [ "${CHANNEL}" == "nightly" ] && ([ "${TARGET}" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "i686-unknown-linux-gnu" ]); then
         "${CARGO}" test --target "${TARGET}" --all-features
         "${CARGO}" test --target "${TARGET}" --all-features --release
     fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           i686-unknown-linux-gnu,
           aarch64-unknown-linux-gnu,
           armv7-unknown-linux-gnueabihf,
-          riscv64gc-unknown-linux-gnu,
+          riscv64gc-unknown-linux-gnu, 
           s390x-unknown-linux-gnu,
 #          mips64-unknown-linux-muslabi64,
 #          loongarch64-unknown-linux-gnu,
@@ -87,7 +87,7 @@ jobs:
             os: ubuntu-latest
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
-          - target: riscv64gc-unknown-linux-gnu
+          - target: riscv64gc-unknown-linux-gnu 
             os: ubuntu-latest
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest


### PR DESCRIPTION
use the newst cross version to fix the problem symbol `statx` not found.

## Discription

This PR is done by the following tasks:
- [x] lock the cross version to the newest master commit
- [x] add `cargo clean` after installing the cross to fix the glibc version problem

## Related Issue

#281 