### PR TITLE
feat: unlink op, remove_file and remove_dir

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -71,6 +71,8 @@ zero-copy = []
 splice = []
 # mkdirat2 op(requires kernel 5.15+)
 mkdirat = []
+# unlinkat op(requires kernel 5.11+)
+unlinkat = []
 # enable `async main` macros support
 macros = ["monoio-macros"]
 # allow waker to be sent across threads

--- a/monoio/src/driver/op.rs
+++ b/monoio/src/driver/op.rs
@@ -25,6 +25,9 @@ mod statx;
 #[cfg(all(unix, feature = "mkdirat"))]
 mod mkdir;
 
+#[cfg(all(unix, feature = "unlinkat"))]
+mod unlink;
+
 #[cfg(all(target_os = "linux", feature = "splice"))]
 mod splice;
 

--- a/monoio/src/driver/op/unlink.rs
+++ b/monoio/src/driver/op/unlink.rs
@@ -1,0 +1,57 @@
+use std::{ffi::CString, io, path::Path};
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+use io_uring::{opcode, squeue::Entry, types::Fd};
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+use libc::{AT_FDCWD, AT_REMOVEDIR};
+
+use super::{Op, OpAble};
+use crate::driver::util::cstr;
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use crate::{driver::ready::Direction, syscall_u32};
+
+pub(crate) struct Unlink {
+    path: CString,
+    remove_dir: bool,
+}
+
+impl Op<Unlink> {
+    pub(crate) fn unlink<P: AsRef<Path>>(path: P) -> io::Result<Op<Unlink>> {
+        let path = cstr(path.as_ref())?;
+        Op::submit_with(Unlink {
+            path,
+            remove_dir: false,
+        })
+    }
+
+    pub(crate) fn rmdir<P: AsRef<Path>>(path: P) -> io::Result<Op<Unlink>> {
+        let path = cstr(path.as_ref())?;
+        Op::submit_with(Unlink {
+            path,
+            remove_dir: true,
+        })
+    }
+}
+
+impl OpAble for Unlink {
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    fn uring_op(&mut self) -> Entry {
+        opcode::UnlinkAt::new(Fd(AT_FDCWD), self.path.as_c_str().as_ptr())
+            .flags(if self.remove_dir { AT_REMOVEDIR } else { 0 })
+            .build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_interest(&self) -> Option<(Direction, usize)> {
+        None
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> io::Result<u32> {
+        if self.remove_dir {
+            syscall_u32!(rmdir(self.path.as_c_str().as_ptr()))
+        } else {
+            syscall_u32!(unlink(self.path.as_c_str().as_ptr()))
+        }
+    }
+}

--- a/monoio/tests/fs_unlink.rs
+++ b/monoio/tests/fs_unlink.rs
@@ -1,0 +1,38 @@
+#![cfg(all(unix, feature = "unlinkat", feature = "mkdirat"))]
+
+use std::{io, path::PathBuf};
+
+use monoio::fs::{self, File};
+use tempfile::tempdir;
+
+async fn create_file(path: &PathBuf) -> io::Result<()> {
+    let file = File::create(path).await?;
+    file.close().await?;
+    Ok(())
+}
+
+#[monoio::test_all]
+async fn remove_file() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("test");
+
+    create_file(&target).await.unwrap();
+    fs::remove_file(&target).await.unwrap();
+    assert!(File::open(&target).await.is_err());
+    assert!(fs::remove_file(&target).await.is_err());
+}
+
+#[monoio::test_all]
+async fn remove_dir() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("test");
+
+    fs::create_dir(&target).await.unwrap();
+    let path = target.join("file");
+    create_file(&path).await.unwrap();
+    assert!(fs::remove_dir(&target).await.is_err()); // dir is not empty
+    fs::remove_file(&path).await.unwrap();
+    fs::remove_dir(&target).await.unwrap();
+    assert!(create_file(&path).await.is_err()); // dir has been removed
+    assert!(fs::remove_dir(&target).await.is_err());
+}


### PR DESCRIPTION
This PR adds `Unlink` op, `remove_file` and `remove_dir` functions and tests. They are implemented for unix only.

`remove_dir_all` is not implemented because `getdents64` is not supported by io_uring and there's currently no way to list nested files and directories with io_uring.