### PR TITLE
refactor!: use `IoBuf` instead of `IoBufMut` in `AsyncWriteRentAt`

### DIFF
--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::{
-    buf::{IoBuf, IoBufMut, IoVecBuf},
+    buf::{IoBuf, IoVecBuf},
     BufResult,
 };
 
@@ -23,8 +23,8 @@ pub trait AsyncWriteRent {
 /// AsyncWriteRentAt: async write with a ownership of a buffer and a position
 pub trait AsyncWriteRentAt {
     /// Write buf at given offset
-    fn write_at<T: IoBufMut>(
-        &self,
+    fn write_at<T: IoBuf>(
+        &mut self,
         buf: T,
         pos: usize,
     ) -> impl Future<Output = BufResult<usize, T>>;


### PR DESCRIPTION
`AsyncWriteRentAt` does not need a mutable buffer such as `AsyncRead`, however, this is a breaking change, please evaluate it.