### PR TITLE
fix: fix an error in CI

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -39,7 +39,7 @@ if [ "${NO_RUN}" != "1" ] && [ "${NO_RUN}" != "true" ]; then
         "${CARGO}" test --target "${TARGET}" --release
     fi
 
-    if [ "${CHANNEL}" == "nightly" ] && ([ "${TARGET}" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "i686-unknown-linux-gnu" ]); then
+    if [ "${CHANNEL}" = "nightly" ] && ([ "${TARGET}" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "i686-unknown-linux-gnu" ]); then
         "${CARGO}" test --target "${TARGET}" --all-features
         "${CARGO}" test --target "${TARGET}" --all-features --release
     fi
@@ -53,7 +53,7 @@ if [ "${NO_RUN}" != "1" ] && [ "${NO_RUN}" != "true" ]; then
     "${CARGO}" test --target "${TARGET}" --no-default-features --features hyper
     "${CARGO}" test --target "${TARGET}" --no-default-features --features hyper --release
 
-    if [ "${CHANNEL}" == "nightly" ]; then
+    if [ "${CHANNEL}" = "nightly" ]; then
         "${CARGO}" test --target "${TARGET}" --all-features
         "${CARGO}" test --target "${TARGET}" --all-features --release
     fi

--- a/monoio/src/blocking.rs
+++ b/monoio/src/blocking.rs
@@ -85,7 +85,9 @@ pub enum BlockingStrategy {
 }
 
 /// `spawn_blocking` is used for executing a task(without async) with heavy computation or blocking
-/// io. To used it, users may initialize a thread pool and attach it on creating runtime.
+/// io.
+///
+/// To used it, users may initialize a thread pool and attach it on creating runtime.
 /// Users can also set `BlockingStrategy` for a runtime when there is no thread pool.
 /// WARNING: DO NOT USE THIS FOR ASYNC TASK! Async tasks will not be executed but only built the
 /// future!

--- a/monoio/tests/fs_symlink.rs
+++ b/monoio/tests/fs_symlink.rs
@@ -22,7 +22,7 @@ async fn create_symlink() {
         .await
         .unwrap();
 
-    let content = monoio::fs::read(dst_file_path).await.unwrap();
+    let content = monoio::fs::read(&dst_file_path).await.unwrap();
     assert_eq!(content, TEST_PAYLOAD);
-    assert(dst_file_path.is_symlink());
+    assert!(dst_file_path.is_symlink());
 }


### PR DESCRIPTION
Find and fix a bug in CI:

When `CHANNEL` is `nightly`, this will happen
```sh
+ [ nightly == nightly ]
.github/workflows/ci.sh: 42: [: nightly: unexpected operator
```

This bug is found because #300 pass all the CI test but failed in code-coverage.

This PR fix this bug, and also fix the error in code-coverage