### PR TITLE
feat: impl IO for some foreign types; rewrite readv/writev impl for some types

### DIFF
--- a/monoio-compat/src/lib.rs
+++ b/monoio-compat/src/lib.rs
@@ -1,7 +1,5 @@
 //! For compat with tokio AsyncRead and AsyncWrite.
 
-#![cfg_attr(feature = "unstable", feature(new_uninit))]
-
 pub mod box_future;
 mod buf;
 

--- a/monoio/src/buf/io_buf.rs
+++ b/monoio/src/buf/io_buf.rs
@@ -39,6 +39,12 @@ pub unsafe trait IoBuf: Unpin + 'static {
     /// For `Vec`, this is identical to `len()`.
     fn bytes_init(&self) -> usize;
 
+    /// Returns a slice of the buffer.
+    #[inline]
+    fn as_slice(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.read_ptr(), self.bytes_init()) }
+    }
+
     /// Returns a view of the buffer with the specified range.
     #[inline]
     fn slice(self, range: impl ops::RangeBounds<usize>) -> Slice<Self>

--- a/monoio/src/fs/file/mod.rs
+++ b/monoio/src/fs/file/mod.rs
@@ -505,8 +505,9 @@ impl File {
         Ok(())
     }
 
-    async fn flush(&mut self) -> io::Result<()> {
-        Ok(())
+    #[inline]
+    fn flush(&mut self) -> impl Future<Output = io::Result<()>> {
+        std::future::ready(Ok(()))
     }
 
     /// Closes the file.

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -331,9 +331,9 @@ impl AsyncWriteRent for TcpStream {
     }
 
     #[inline]
-    async fn flush(&mut self) -> std::io::Result<()> {
+    fn flush(&mut self) -> impl Future<Output = std::io::Result<()>> {
         // Tcp stream does not need flush.
-        Ok(())
+        std::future::ready(Ok(()))
     }
 
     fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
@@ -347,7 +347,7 @@ impl AsyncWriteRent for TcpStream {
             -1 => Err(io::Error::last_os_error()),
             _ => Ok(()),
         };
-        async move { res }
+        std::future::ready(res)
     }
 }
 
@@ -403,7 +403,7 @@ impl CancelableAsyncWriteRent for TcpStream {
             -1 => Err(io::Error::last_os_error()),
             _ => Ok(()),
         };
-        async move { res }
+        std::future::ready(res)
     }
 }
 


### PR DESCRIPTION
1. Add `AsyncReadRent` impl for `Cursor<T>`, `Box<T>`; `AsyncWriteRent` for `Vec<u8>`
2. Rewrite `readv` for `&[u8]`
3. Impl `AsyncReadRentAt`/`AsyncWriteRentAt` for `&mut A` when `A` implements the coresponding trait
4. Small change: change `async move { .. }` to `std::future::ready(..)`

Related issue: #310