### PR TITLE
fix: properly close fd when return-fd op cancelled failed

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -63,6 +63,7 @@ tempfile = "3.2"
 # use nightly only feature flags
 unstable = []
 # async-cancel will push a async-cancel entry into sq when op is canceled
+# strongly recommend to enable this feature
 async-cancel = []
 # enanle zero copy(enable SOCK_ZEROCOPY + MSG_ZEROCOPY flag)
 # WARNING: this feature may cause performance degradation

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -160,17 +160,9 @@ impl Inner {
     #[inline]
     fn drop_op<T: 'static>(&self, index: usize, data: &mut Option<T>, skip_cancel: bool) {
         match self {
-            #[cfg(all(target_os = "linux", feature = "iouring"))]
             Inner::Uring(this) => UringInner::drop_op(this, index, data, skip_cancel),
             #[cfg(feature = "legacy")]
             Inner::Legacy(_) => {}
-            #[cfg(all(
-                not(feature = "legacy"),
-                not(all(target_os = "linux", feature = "iouring"))
-            ))]
-            _ => {
-                util::feature_panic();
-            }
         }
     }
 

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -157,10 +157,11 @@ impl Inner {
     }
 
     #[allow(unused)]
-    fn drop_op<T: 'static>(&self, index: usize, data: &mut Option<T>) {
+    #[inline]
+    fn drop_op<T: 'static>(&self, index: usize, data: &mut Option<T>, skip_cancel: bool) {
         match self {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
-            Inner::Uring(this) => UringInner::drop_op(this, index, data),
+            Inner::Uring(this) => UringInner::drop_op(this, index, data, skip_cancel),
             #[cfg(feature = "legacy")]
             Inner::Legacy(_) => {}
             #[cfg(all(

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -156,7 +156,7 @@ impl Inner {
         }
     }
 
-    #[allow(unused)]
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
     #[inline]
     fn drop_op<T: 'static>(&self, index: usize, data: &mut Option<T>, skip_cancel: bool) {
         match self {

--- a/monoio/src/driver/op.rs
+++ b/monoio/src/driver/op.rs
@@ -109,6 +109,11 @@ impl MaybeFd {
             fd: 0,
         }
     }
+
+    #[inline]
+    pub(crate) fn fd(&self) -> u32 {
+        self.fd
+    }
 }
 
 impl Drop for MaybeFd {
@@ -237,6 +242,7 @@ where
     }
 }
 
+#[cfg(all(target_os = "linux", feature = "iouring"))]
 impl<T: OpAble> Drop for Op<T> {
     #[inline]
     fn drop(&mut self) {

--- a/monoio/src/driver/op.rs
+++ b/monoio/src/driver/op.rs
@@ -63,6 +63,12 @@ pub(crate) struct CompletionMeta {
     pub(crate) flags: u32,
 }
 
+/// MaybeFd is a wrapper for fd or a normal number. If it is marked as fd, it will close the fd when
+/// dropped.
+/// Use `into_inner` to take the inner fd or number and skip the drop.
+///
+/// This wrapper is designed to be used in the syscall return value. It can prevent fd leak when the
+/// operation is cancelled.
 #[derive(Debug)]
 pub(crate) struct MaybeFd {
     is_fd: bool,

--- a/monoio/src/driver/op/accept.rs
+++ b/monoio/src/driver/op/accept.rs
@@ -121,9 +121,9 @@ impl OpAble for Accept {
         ))]
         return {
             let stream_fd = syscall_u32!(accept@FD(fd, addr, len))?;
-            let fd = stream_fd.get() as i32;
-            syscall_u32!(fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC))?;
-            syscall_u32!(fcntl(fd, libc::F_SETFL, libc::O_NONBLOCK))?;
+            let fd = stream_fd.fd() as i32;
+            syscall_u32!(fcntl@RAW(fd, libc::F_SETFD, libc::FD_CLOEXEC))?;
+            syscall_u32!(fcntl@RAW(fd, libc::F_SETFL, libc::O_NONBLOCK))?;
             Ok(stream_fd)
         };
     }

--- a/monoio/src/driver/op/close.rs
+++ b/monoio/src/driver/op/close.rs
@@ -5,10 +5,7 @@ use std::os::unix::io::RawFd;
 #[cfg(all(target_os = "linux", feature = "iouring"))]
 use io_uring::{opcode, types};
 #[cfg(windows)]
-use {
-    crate::syscall, std::os::windows::io::RawSocket,
-    windows_sys::Win32::Networking::WinSock::closesocket,
-};
+use {std::os::windows::io::RawSocket, windows_sys::Win32::Networking::WinSock::closesocket};
 
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
 use super::MaybeFd;
@@ -52,9 +49,9 @@ impl OpAble for Close {
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(unix)]
-        return crate::syscall_u32!(close@NON_FD(self.fd));
+        return crate::syscall!(close@NON_FD(self.fd));
 
         #[cfg(windows)]
-        return syscall!(closesocket@NON_FD(self.fd as _), PartialEq::ne, 0);
+        return crate::syscall!(closesocket@NON_FD(self.fd as _), PartialEq::ne, 0);
     }
 }

--- a/monoio/src/driver/op/connect.rs
+++ b/monoio/src/driver/op/connect.rs
@@ -70,7 +70,7 @@ impl OpAble for Connect {
             endpoints.sae_dstaddr = self.socket_addr.as_ptr();
             endpoints.sae_dstaddrlen = self.socket_addr_len;
 
-            return match crate::syscall_u32!(connectx@RAW(
+            return match crate::syscall!(connectx@RAW(
                 self.fd.raw_fd(),
                 &endpoints as *const _,
                 libc::SAE_ASSOCID_ANY,
@@ -86,7 +86,7 @@ impl OpAble for Connect {
         }
 
         #[cfg(unix)]
-        match crate::syscall_u32!(connect@RAW(
+        match crate::syscall!(connect@RAW(
             self.fd.raw_fd(),
             self.socket_addr.as_ptr(),
             self.socket_addr_len,
@@ -158,7 +158,7 @@ impl OpAble for ConnectUnix {
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
-        match crate::syscall_u32!(connect@RAW(
+        match crate::syscall!(connect@RAW(
             self.fd.raw_fd(),
             &self.socket_addr.0 as *const _ as *const _,
             self.socket_addr.1

--- a/monoio/src/driver/op/connect.rs
+++ b/monoio/src/driver/op/connect.rs
@@ -10,7 +10,7 @@ use windows_sys::Win32::Networking::WinSock::{
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::driver::ready::Direction;
+use super::{driver::ready::Direction, MaybeFd};
 
 pub(crate) struct Connect {
     pub(crate) fd: SharedFd,
@@ -59,7 +59,7 @@ impl OpAble for Connect {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         // For ios/macos, if tfo is enabled, we will
         // call connectx here.
         // For linux/android, we have already set socket
@@ -70,7 +70,7 @@ impl OpAble for Connect {
             endpoints.sae_dstaddr = self.socket_addr.as_ptr();
             endpoints.sae_dstaddrlen = self.socket_addr_len;
 
-            return match crate::syscall_u32!(connectx(
+            return match crate::syscall_u32!(connectx@RAW(
                 self.fd.raw_fd(),
                 &endpoints as *const _,
                 libc::SAE_ASSOCID_ANY,
@@ -81,18 +81,18 @@ impl OpAble for Connect {
                 std::ptr::null_mut(),
             )) {
                 Err(err) if err.raw_os_error() != Some(libc::EINPROGRESS) => Err(err),
-                _ => Ok(self.fd.raw_fd() as u32),
+                _ => Ok(MaybeFd::zero()),
             };
         }
 
         #[cfg(unix)]
-        match crate::syscall_u32!(connect(
+        match crate::syscall_u32!(connect@RAW(
             self.fd.raw_fd(),
             self.socket_addr.as_ptr(),
             self.socket_addr_len,
         )) {
             Err(err) if err.raw_os_error() != Some(libc::EINPROGRESS) => Err(err),
-            _ => Ok(self.fd.raw_fd() as u32),
+            _ => Ok(MaybeFd::zero()),
         }
 
         #[cfg(windows)]
@@ -110,8 +110,7 @@ impl OpAble for Connect {
                     return Err(err);
                 }
             }
-            #[allow(clippy::unnecessary_cast)]
-            Ok(self.fd.raw_socket() as u32)
+            Ok(MaybeFd::zero())
         }
     }
 }
@@ -158,14 +157,14 @@ impl OpAble for ConnectUnix {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
-        match crate::syscall_u32!(connect(
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
+        match crate::syscall_u32!(connect@RAW(
             self.fd.raw_fd(),
             &self.socket_addr.0 as *const _ as *const _,
             self.socket_addr.1
         )) {
             Err(err) if err.raw_os_error() != Some(libc::EINPROGRESS) => Err(err),
-            _ => Ok(self.fd.raw_fd() as u32),
+            _ => Ok(MaybeFd::zero()),
         }
     }
 }

--- a/monoio/src/driver/op/fsync.rs
+++ b/monoio/src/driver/op/fsync.rs
@@ -63,15 +63,13 @@ impl OpAble for Fsync {
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
-        use crate::syscall_u32;
-
         #[cfg(target_os = "linux")]
         if self.data_sync {
-            syscall_u32!(fdatasync@NON_FD(self.fd.raw_fd()))
+            crate::syscall!(fdatasync@NON_FD(self.fd.raw_fd()))
         } else {
-            syscall_u32!(fsync@NON_FD(self.fd.raw_fd()))
+            crate::syscall!(fsync@NON_FD(self.fd.raw_fd()))
         }
         #[cfg(not(target_os = "linux"))]
-        syscall_u32!(fsync@NON_FD(self.fd.raw_fd()))
+        crate::syscall!(fsync@NON_FD(self.fd.raw_fd()))
     }
 }

--- a/monoio/src/driver/op/fsync.rs
+++ b/monoio/src/driver/op/fsync.rs
@@ -52,8 +52,10 @@ impl OpAble for Fsync {
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         use std::os::windows::prelude::AsRawHandle;
 
+        use windows_sys::Win32::Storage::FileSystem::FlushFileBuffers;
+
         crate::syscall!(
-            windows_sys::Win32::Storage::FileSystem::FlushFileBuffers@NON_FD(self.fd.as_raw_handle() as _),
+            FlushFileBuffers@NON_FD(self.fd.as_raw_handle() as _),
             PartialEq::eq,
             0
         )

--- a/monoio/src/driver/op/mkdir.rs
+++ b/monoio/src/driver/op/mkdir.rs
@@ -37,9 +37,7 @@ impl OpAble for MkDir {
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
-        use crate::syscall_u32;
-
-        syscall_u32!(mkdirat@NON_FD(
+        crate::syscall!(mkdirat@NON_FD(
             libc::AT_FDCWD,
             self.path.as_ptr(),
             self.mode

--- a/monoio/src/driver/op/mkdir.rs
+++ b/monoio/src/driver/op/mkdir.rs
@@ -2,6 +2,8 @@ use std::{ffi::CString, path::Path};
 
 use libc::mode_t;
 
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use super::MaybeFd;
 use super::{Op, OpAble};
 use crate::driver::util::cstr;
 
@@ -34,14 +36,18 @@ impl OpAble for MkDir {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use crate::syscall_u32;
 
-        syscall_u32!(mkdirat(libc::AT_FDCWD, self.path.as_ptr(), self.mode))
+        syscall_u32!(mkdirat@NON_FD(
+            libc::AT_FDCWD,
+            self.path.as_ptr(),
+            self.mode
+        ))
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         unimplemented!()
     }
 }

--- a/monoio/src/driver/op/open.rs
+++ b/monoio/src/driver/op/open.rs
@@ -2,14 +2,10 @@ use std::{ffi::CString, io, path::Path};
 
 #[cfg(all(target_os = "linux", feature = "iouring"))]
 use io_uring::{opcode, types};
-#[cfg(windows)]
-use windows_sys::Win32::{Foundation::INVALID_HANDLE_VALUE, Storage::FileSystem::CreateFileW};
 
-use super::{Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::driver::ready::Direction;
-#[cfg(windows)]
-use crate::syscall;
+use super::{driver::ready::Direction, MaybeFd};
+use super::{Op, OpAble};
 #[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
 use crate::syscall_u32;
 use crate::{driver::util::cstr, fs::OpenOptions};
@@ -55,6 +51,9 @@ impl Op<Open> {
 
 impl OpAble for Open {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const RET_IS_FD: bool = true;
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
         opcode::OpenAt::new(types::Fd(libc::AT_FDCWD), self.path.as_c_str().as_ptr())
             .flags(self.flags)
@@ -69,8 +68,8 @@ impl OpAble for Open {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), not(windows)))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
-        syscall_u32!(open(
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
+        syscall_u32!(open@FD(
             self.path.as_c_str().as_ptr(),
             self.flags,
             self.mode as libc::c_int
@@ -78,15 +77,20 @@ impl OpAble for Open {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         use std::{ffi::OsString, os::windows::ffi::OsStrExt};
+
+        use windows_sys::Win32::{
+            Foundation::INVALID_HANDLE_VALUE, Storage::FileSystem::CreateFileW,
+        };
 
         let os_str = OsString::from(self.path.to_string_lossy().into_owned());
 
         // Convert OsString to wide character format (Vec<u16>).
         let wide_path: Vec<u16> = os_str.encode_wide().chain(Some(0)).collect();
-        syscall!(
-            CreateFileW(
+
+        crate::syscall!(
+            CreateFileW@FD(
                 wide_path.as_ptr(),
                 self.opts.access_mode()?,
                 self.opts.share_mode,

--- a/monoio/src/driver/op/open.rs
+++ b/monoio/src/driver/op/open.rs
@@ -6,8 +6,6 @@ use io_uring::{opcode, types};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
 use super::{driver::ready::Direction, MaybeFd};
 use super::{Op, OpAble};
-#[cfg(all(unix, any(feature = "legacy", feature = "poll-io")))]
-use crate::syscall_u32;
 use crate::{driver::util::cstr, fs::OpenOptions};
 
 /// Open a file
@@ -69,7 +67,7 @@ impl OpAble for Open {
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), not(windows)))]
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
-        syscall_u32!(open@FD(
+        crate::syscall!(open@FD(
             self.path.as_c_str().as_ptr(),
             self.flags,
             self.mode as libc::c_int

--- a/monoio/src/driver/op/poll.rs
+++ b/monoio/src/driver/op/poll.rs
@@ -85,7 +85,7 @@ impl OpAble for PollAdd {
                 },
                 revents: 0,
             };
-            let ret = crate::syscall_u32!(poll@RAW(&mut pollfd as *mut _, 1, 0))?;
+            let ret = crate::syscall!(poll@RAW(&mut pollfd as *mut _, 1, 0))?;
             if ret == 0 {
                 return Err(ErrorKind::WouldBlock.into());
             }

--- a/monoio/src/driver/op/read.rs
+++ b/monoio/src/driver/op/read.rs
@@ -9,7 +9,7 @@ use io_uring::{opcode, types};
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::driver::ready::Direction;
+use super::{driver::ready::Direction, MaybeFd};
 use crate::{
     buf::{IoBufMut, IoVecBufMut},
     BufResult,
@@ -23,7 +23,7 @@ macro_rules! read_result {
                     let complete = self.await;
 
                     // Convert the operation result to `usize`
-                    let res = complete.meta.result.map(|v| v as usize);
+                    let res = complete.meta.result.map(|v| v.into_inner() as usize);
                     // Recover the buffer
                     let mut buf = complete.data.$buf;
 
@@ -86,7 +86,7 @@ impl<T: IoBufMut> OpAble for Read<T> {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(unix)]
         let fd = self.fd.as_raw_fd();
 
@@ -131,7 +131,7 @@ impl<T: IoBufMut> OpAble for ReadAt<T> {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(unix)]
         let fd = self.fd.as_raw_fd();
         #[cfg(windows)]
@@ -179,7 +179,7 @@ impl<T: IoVecBufMut> OpAble for ReadVec<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         read_vectored(
             self.fd.raw_fd(),
             self.buf_vec.write_iovec_ptr(),
@@ -188,7 +188,7 @@ impl<T: IoVecBufMut> OpAble for ReadVec<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         // There is no `readv`-like syscall of file on windows, but this will be used to send
         // socket message.
 
@@ -208,11 +208,11 @@ impl<T: IoVecBufMut> OpAble for ReadVec<T> {
             )
         };
         match ret {
-            0 => Ok(nread),
+            0 => Ok(MaybeFd::new_non_fd(nread)),
             _ => {
                 let error = unsafe { WSAGetLastError() };
                 if error == WSAESHUTDOWN {
-                    Ok(0)
+                    Ok(MaybeFd::zero())
                 } else {
                     Err(io::Error::from_raw_os_error(error))
                 }
@@ -257,7 +257,7 @@ impl<T: IoVecBufMut> OpAble for ReadVecAt<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         read_vectored_at(
             self.fd.raw_fd(),
             self.buf_vec.write_iovec_ptr(),
@@ -267,7 +267,7 @@ impl<T: IoVecBufMut> OpAble for ReadVecAt<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         // There is no `readv` like syscall of file on windows, but this will be used to send
         // socket message.
 
@@ -295,11 +295,11 @@ impl<T: IoVecBufMut> OpAble for ReadVecAt<T> {
             )
         };
         match ret {
-            0 => Ok(nread),
+            0 => Ok(MaybeFd::new_non_fd(nread)),
             _ => {
                 let error = unsafe { WSAGetLastError() };
                 if error == WSAESHUTDOWN {
-                    Ok(0)
+                    Ok(MaybeFd::zero())
                 } else {
                     Err(io::Error::from_raw_os_error(error))
                 }
@@ -316,21 +316,21 @@ pub(crate) mod impls {
     use crate::syscall_u32;
 
     /// A wrapper for [`libc::read`]
-    pub(crate) fn read(fd: i32, buf: *mut u8, len: usize) -> io::Result<u32> {
-        syscall_u32!(read(fd, buf as _, len))
+    pub(crate) fn read(fd: i32, buf: *mut u8, len: usize) -> io::Result<MaybeFd> {
+        syscall_u32!(read@NON_FD(fd, buf as _, len))
     }
 
     /// A wrapper of [`libc::pread`]
-    pub(crate) fn read_at(fd: i32, buf: *mut u8, len: usize, offset: u64) -> io::Result<u32> {
+    pub(crate) fn read_at(fd: i32, buf: *mut u8, len: usize, offset: u64) -> io::Result<MaybeFd> {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(pread(fd, buf as _, len, offset))
+        syscall_u32!(pread@NON_FD(fd, buf as _, len, offset))
     }
 
     /// A wrapper of [`libc::readv`]
-    pub(crate) fn read_vectored(fd: i32, buf_vec: *mut iovec, len: usize) -> io::Result<u32> {
-        syscall_u32!(readv(fd, buf_vec as _, len as _))
+    pub(crate) fn read_vectored(fd: i32, buf_vec: *mut iovec, len: usize) -> io::Result<MaybeFd> {
+        syscall_u32!(readv@NON_FD(fd, buf_vec as _, len as _))
     }
 
     /// A wrapper of [`libc::preadv`]
@@ -339,11 +339,11 @@ pub(crate) mod impls {
         buf_vec: *mut iovec,
         len: usize,
         offset: u64,
-    ) -> io::Result<u32> {
+    ) -> io::Result<MaybeFd> {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(preadv(fd, buf_vec as _, len as _, offset))
+        syscall_u32!(preadv@NON_FD(fd, buf_vec as _, len as _, offset))
     }
 }
 

--- a/monoio/src/driver/op/read.rs
+++ b/monoio/src/driver/op/read.rs
@@ -313,11 +313,10 @@ pub(crate) mod impls {
     use libc::iovec;
 
     use super::*;
-    use crate::syscall_u32;
 
     /// A wrapper for [`libc::read`]
     pub(crate) fn read(fd: i32, buf: *mut u8, len: usize) -> io::Result<MaybeFd> {
-        syscall_u32!(read@NON_FD(fd, buf as _, len))
+        crate::syscall!(read@NON_FD(fd, buf as _, len))
     }
 
     /// A wrapper of [`libc::pread`]
@@ -325,12 +324,12 @@ pub(crate) mod impls {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(pread@NON_FD(fd, buf as _, len, offset))
+        crate::syscall!(pread@NON_FD(fd, buf as _, len, offset))
     }
 
     /// A wrapper of [`libc::readv`]
     pub(crate) fn read_vectored(fd: i32, buf_vec: *mut iovec, len: usize) -> io::Result<MaybeFd> {
-        syscall_u32!(readv@NON_FD(fd, buf_vec as _, len as _))
+        crate::syscall!(readv@NON_FD(fd, buf_vec as _, len as _))
     }
 
     /// A wrapper of [`libc::preadv`]
@@ -343,7 +342,7 @@ pub(crate) mod impls {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(preadv@NON_FD(fd, buf_vec as _, len as _, offset))
+        crate::syscall!(preadv@NON_FD(fd, buf_vec as _, len as _, offset))
     }
 }
 

--- a/monoio/src/driver/op/recv.rs
+++ b/monoio/src/driver/op/recv.rs
@@ -109,8 +109,8 @@ impl<T: IoBufMut> OpAble for Recv<T> {
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         let fd = self.fd.as_raw_socket();
-        MaybeFd::new_non_fd_result(crate::syscall!(
-            recv(
+        crate::syscall!(
+            recv@NON_FD(
                 fd as _,
                 self.buf.write_ptr(),
                 self.buf.bytes_total().min(i32::MAX as usize) as _,
@@ -118,7 +118,7 @@ impl<T: IoBufMut> OpAble for Recv<T> {
             ),
             PartialOrd::lt,
             0
-        ))
+        )
     }
 }
 

--- a/monoio/src/driver/op/rename.rs
+++ b/monoio/src/driver/op/rename.rs
@@ -1,5 +1,7 @@
 use std::{ffi::CString, path::Path};
 
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use super::MaybeFd;
 use super::{Op, OpAble};
 use crate::driver::util::cstr;
 
@@ -37,10 +39,10 @@ impl OpAble for Rename {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use crate::syscall_u32;
 
-        syscall_u32!(renameat(
+        syscall_u32!(renameat@NON_FD(
             libc::AT_FDCWD,
             self.from.as_ptr(),
             libc::AT_FDCWD,
@@ -49,7 +51,7 @@ impl OpAble for Rename {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         unimplemented!()
     }
 }

--- a/monoio/src/driver/op/rename.rs
+++ b/monoio/src/driver/op/rename.rs
@@ -40,9 +40,7 @@ impl OpAble for Rename {
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
-        use crate::syscall_u32;
-
-        syscall_u32!(renameat@NON_FD(
+        crate::syscall!(renameat@NON_FD(
             libc::AT_FDCWD,
             self.from.as_ptr(),
             libc::AT_FDCWD,

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -113,7 +113,7 @@ impl<T: IoBuf> OpAble for Send<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         let fd = self.fd.as_raw_socket();
         syscall!(
             send@NON_FD(fd as _, self.buf.read_ptr(), self.buf.bytes_init() as _, 0),
@@ -219,7 +219,7 @@ impl<T: IoBuf> OpAble for SendMsg<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         let fd = self.fd.as_raw_socket();
         let mut nsent = 0;
         let ret = unsafe {
@@ -235,7 +235,7 @@ impl<T: IoBuf> OpAble for SendMsg<T> {
         if ret == SOCKET_ERROR {
             Err(io::Error::last_os_error())
         } else {
-            Ok(nsent)
+            Ok(MaybeFd::new_non_fd(nsent))
         }
     }
 }

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -14,7 +14,7 @@ use {crate::syscall_u32, std::os::unix::prelude::AsRawFd};
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::driver::ready::Direction;
+use super::{driver::ready::Direction, MaybeFd};
 #[cfg(unix)]
 use crate::net::unix::SocketAddr as UnixSocketAddr;
 use crate::{
@@ -46,7 +46,10 @@ impl<T: IoBuf> Op<Send<T>> {
 
     pub(crate) async fn result(self) -> BufResult<usize, T> {
         let complete = self.await;
-        (complete.meta.result.map(|v| v as _), complete.data.buf)
+        (
+            complete.meta.result.map(|v| v.into_inner() as _),
+            complete.data.buf,
+        )
     }
 }
 
@@ -93,7 +96,7 @@ impl<T: IoBuf> OpAble for Send<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         let fd = self.fd.as_raw_fd();
         #[cfg(target_os = "linux")]
         #[allow(deprecated)]
@@ -101,7 +104,7 @@ impl<T: IoBuf> OpAble for Send<T> {
         #[cfg(not(target_os = "linux"))]
         let flags = 0;
 
-        syscall_u32!(send(
+        syscall_u32!(send@NON_FD(
             fd,
             self.buf.read_ptr() as _,
             self.buf.bytes_init(),
@@ -113,7 +116,7 @@ impl<T: IoBuf> OpAble for Send<T> {
     fn legacy_call(&mut self) -> io::Result<u32> {
         let fd = self.fd.as_raw_socket();
         syscall!(
-            send(fd as _, self.buf.read_ptr(), self.buf.bytes_init() as _, 0),
+            send@NON_FD(fd as _, self.buf.read_ptr(), self.buf.bytes_init() as _, 0),
             PartialOrd::lt,
             0
         )
@@ -180,7 +183,7 @@ impl<T: IoBuf> Op<SendMsg<T>> {
 
     pub(crate) async fn wait(self) -> BufResult<usize, T> {
         let complete = self.await;
-        let res = complete.meta.result.map(|v| v as _);
+        let res = complete.meta.result.map(|v| v.into_inner() as _);
         let buf = complete.data.buf;
         (res, buf)
     }
@@ -205,14 +208,14 @@ impl<T: IoBuf> OpAble for SendMsg<T> {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), unix))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(target_os = "linux")]
         #[allow(deprecated)]
         const FLAGS: libc::c_int = libc::MSG_NOSIGNAL as libc::c_int;
         #[cfg(not(target_os = "linux"))]
         const FLAGS: libc::c_int = 0;
         let fd = self.fd.as_raw_fd();
-        syscall_u32!(sendmsg(fd, &*self.info.2, FLAGS))
+        syscall_u32!(sendmsg@NON_FD(fd, &*self.info.2, FLAGS))
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
@@ -282,7 +285,7 @@ impl<T: IoBuf> Op<SendMsgUnix<T>> {
 
     pub(crate) async fn wait(self) -> BufResult<usize, T> {
         let complete = self.await;
-        let res = complete.meta.result.map(|v| v as _);
+        let res = complete.meta.result.map(|v| v.into_inner() as _);
         let buf = complete.data.buf;
         (res, buf)
     }
@@ -309,13 +312,13 @@ impl<T: IoBuf> OpAble for SendMsgUnix<T> {
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
     #[inline]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(target_os = "linux")]
         #[allow(deprecated)]
         const FLAGS: libc::c_int = libc::MSG_NOSIGNAL as libc::c_int;
         #[cfg(not(target_os = "linux"))]
         const FLAGS: libc::c_int = 0;
         let fd = self.fd.as_raw_fd();
-        syscall_u32!(sendmsg(fd, &mut self.info.2 as *mut _, FLAGS))
+        syscall_u32!(sendmsg@NON_FD(fd, &mut self.info.2 as *mut _, FLAGS))
     }
 }

--- a/monoio/src/driver/op/splice.rs
+++ b/monoio/src/driver/op/splice.rs
@@ -6,10 +6,7 @@ use std::io;
 use io_uring::{opcode, types};
 #[cfg(all(unix, feature = "legacy"))]
 use {
-    crate::{
-        driver::{op::MaybeFd, ready::Direction},
-        syscall_u32,
-    },
+    crate::driver::{op::MaybeFd, ready::Direction},
     std::os::unix::prelude::AsRawFd,
 };
 
@@ -97,7 +94,7 @@ impl OpAble for Splice {
         let fd_out = self.fd_out.as_raw_fd();
         let off_in = std::ptr::null_mut::<libc::loff_t>();
         let off_out = std::ptr::null_mut::<libc::loff_t>();
-        syscall_u32!(splice@NON_FD(
+        crate::syscall!(splice@NON_FD(
             fd_in,
             off_in,
             fd_out,

--- a/monoio/src/driver/op/statx.rs
+++ b/monoio/src/driver/op/statx.rs
@@ -86,7 +86,7 @@ impl OpAble for FdStatx {
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use std::os::fd::AsRawFd;
 
-        crate::syscall_u32!(statx@NON_FD(
+        crate::syscall!(statx@NON_FD(
             self.inner.as_raw_fd(),
             c"".as_ptr(),
             libc::AT_EMPTY_PATH,
@@ -104,7 +104,7 @@ impl OpAble for FdStatx {
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use std::os::fd::AsRawFd;
 
-        crate::syscall_u32!(fstat@NON_FD(
+        crate::syscall!(fstat@NON_FD(
             self.inner.as_raw_fd(),
             self.stat_buf.as_mut_ptr() as *mut _
         ))
@@ -173,7 +173,7 @@ impl OpAble for PathStatx {
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "linux"))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
-        crate::syscall_u32!(statx@NON_FD(
+        crate::syscall!(statx@NON_FD(
             libc::AT_FDCWD,
             self.inner.as_ptr(),
             self.flags,
@@ -190,12 +190,12 @@ impl OpAble for PathStatx {
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "macos"))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         if self.follow_symlinks {
-            crate::syscall_u32!(stat@NON_FD(
+            crate::syscall!(stat@NON_FD(
                 self.inner.as_ptr(),
                 self.stat_buf.as_mut_ptr() as *mut _
             ))
         } else {
-            crate::syscall_u32!(lstat@NON_FD(
+            crate::syscall!(lstat@NON_FD(
                 self.inner.as_ptr(),
                 self.stat_buf.as_mut_ptr() as *mut _
             ))

--- a/monoio/src/driver/op/statx.rs
+++ b/monoio/src/driver/op/statx.rs
@@ -5,9 +5,9 @@ use io_uring::{opcode, types};
 #[cfg(target_os = "linux")]
 use libc::statx;
 
-use super::{Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::driver::ready::Direction;
+use super::{driver::ready::Direction, MaybeFd};
+use super::{Op, OpAble};
 use crate::driver::{shared_fd::SharedFd, util::cstr};
 
 #[derive(Debug)]
@@ -83,12 +83,10 @@ impl OpAble for FdStatx {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "linux"))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use std::os::fd::AsRawFd;
 
-        use crate::syscall_u32;
-
-        syscall_u32!(statx(
+        crate::syscall_u32!(statx@NON_FD(
             self.inner.as_raw_fd(),
             c"".as_ptr(),
             libc::AT_EMPTY_PATH,
@@ -98,17 +96,15 @@ impl OpAble for FdStatx {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         unimplemented!()
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "macos"))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use std::os::fd::AsRawFd;
 
-        use crate::syscall_u32;
-
-        syscall_u32!(fstat(
+        crate::syscall_u32!(fstat@NON_FD(
             self.inner.as_raw_fd(),
             self.stat_buf.as_mut_ptr() as *mut _
         ))
@@ -176,10 +172,8 @@ impl OpAble for PathStatx {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "linux"))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
-        use crate::syscall_u32;
-
-        syscall_u32!(statx(
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
+        crate::syscall_u32!(statx@NON_FD(
             libc::AT_FDCWD,
             self.inner.as_ptr(),
             self.flags,
@@ -189,21 +183,19 @@ impl OpAble for PathStatx {
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), windows))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         unimplemented!()
     }
 
     #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "macos"))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
-        use crate::syscall_u32;
-
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         if self.follow_symlinks {
-            syscall_u32!(stat(
+            crate::syscall_u32!(stat@NON_FD(
                 self.inner.as_ptr(),
                 self.stat_buf.as_mut_ptr() as *mut _
             ))
         } else {
-            syscall_u32!(lstat(
+            crate::syscall_u32!(lstat@NON_FD(
                 self.inner.as_ptr(),
                 self.stat_buf.as_mut_ptr() as *mut _
             ))

--- a/monoio/src/driver/op/symlink.rs
+++ b/monoio/src/driver/op/symlink.rs
@@ -1,5 +1,7 @@
 use std::{ffi::CString, io, path::Path};
 
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use super::{driver::ready::Direction, MaybeFd};
 use super::{Op, OpAble};
 use crate::driver::util::cstr;
 
@@ -28,14 +30,13 @@ impl OpAble for Symlink {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_interest(&self) -> Option<(crate::driver::ready::Direction, usize)> {
+    fn legacy_interest(&self) -> Option<(Direction, usize)> {
         None
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> std::io::Result<u32> {
-        use crate::syscall_u32;
-        syscall_u32!(symlink(
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
+        crate::syscall_u32!(symlink@NON_FD(
             self.from.as_c_str().as_ptr(),
             self.to.as_c_str().as_ptr()
         ))

--- a/monoio/src/driver/op/symlink.rs
+++ b/monoio/src/driver/op/symlink.rs
@@ -36,7 +36,7 @@ impl OpAble for Symlink {
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
-        crate::syscall_u32!(symlink@NON_FD(
+        crate::syscall!(symlink@NON_FD(
             self.from.as_c_str().as_ptr(),
             self.to.as_c_str().as_ptr()
         ))

--- a/monoio/src/driver/op/unlink.rs
+++ b/monoio/src/driver/op/unlink.rs
@@ -8,7 +8,10 @@ use libc::{AT_FDCWD, AT_REMOVEDIR};
 use super::{Op, OpAble};
 use crate::driver::util::cstr;
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::{driver::ready::Direction, syscall_u32};
+use crate::{
+    driver::{op::MaybeFd, ready::Direction},
+    syscall_u32,
+};
 
 pub(crate) struct Unlink {
     path: CString,
@@ -47,11 +50,11 @@ impl OpAble for Unlink {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         if self.remove_dir {
-            syscall_u32!(rmdir(self.path.as_c_str().as_ptr()))
+            syscall_u32!(rmdir@NON_FD(self.path.as_c_str().as_ptr()))
         } else {
-            syscall_u32!(unlink(self.path.as_c_str().as_ptr()))
+            syscall_u32!(unlink@NON_FD(self.path.as_c_str().as_ptr()))
         }
     }
 }

--- a/monoio/src/driver/op/unlink.rs
+++ b/monoio/src/driver/op/unlink.rs
@@ -8,10 +8,7 @@ use libc::{AT_FDCWD, AT_REMOVEDIR};
 use super::{Op, OpAble};
 use crate::driver::util::cstr;
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::{
-    driver::{op::MaybeFd, ready::Direction},
-    syscall_u32,
-};
+use crate::driver::{op::MaybeFd, ready::Direction};
 
 pub(crate) struct Unlink {
     path: CString,
@@ -52,9 +49,9 @@ impl OpAble for Unlink {
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
     fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         if self.remove_dir {
-            syscall_u32!(rmdir@NON_FD(self.path.as_c_str().as_ptr()))
+            crate::syscall!(rmdir@NON_FD(self.path.as_c_str().as_ptr()))
         } else {
-            syscall_u32!(unlink@NON_FD(self.path.as_c_str().as_ptr()))
+            crate::syscall!(unlink@NON_FD(self.path.as_c_str().as_ptr()))
         }
     }
 }

--- a/monoio/src/driver/op/write.rs
+++ b/monoio/src/driver/op/write.rs
@@ -252,11 +252,10 @@ pub(crate) mod impls {
     use libc::iovec;
 
     use super::*;
-    use crate::syscall_u32;
 
     /// A wrapper of [`libc::write`]
     pub(crate) fn write(fd: i32, buf: *const u8, len: usize) -> io::Result<MaybeFd> {
-        syscall_u32!(write@NON_FD(fd, buf as _, len))
+        crate::syscall!(write@NON_FD(fd, buf as _, len))
     }
 
     /// A wrapper of [`libc::write`]
@@ -269,7 +268,7 @@ pub(crate) mod impls {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(pwrite@NON_FD(fd, buf as _, len, offset))
+        crate::syscall!(pwrite@NON_FD(fd, buf as _, len, offset))
     }
 
     /// A wrapper of [`libc::writev`]
@@ -278,7 +277,7 @@ pub(crate) mod impls {
         buf_vec: *const iovec,
         len: usize,
     ) -> io::Result<MaybeFd> {
-        syscall_u32!(writev@NON_FD(fd, buf_vec as _, len as _))
+        crate::syscall!(writev@NON_FD(fd, buf_vec as _, len as _))
     }
 
     /// A wrapper of [`libc::pwritev`]
@@ -291,7 +290,7 @@ pub(crate) mod impls {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(pwritev@NON_FD(fd, buf_vec as _, len as _, offset))
+        crate::syscall!(pwritev@NON_FD(fd, buf_vec as _, len as _, offset))
     }
 }
 

--- a/monoio/src/driver/op/write.rs
+++ b/monoio/src/driver/op/write.rs
@@ -13,7 +13,7 @@ use windows_sys::Win32::{Foundation::TRUE, Storage::FileSystem::WriteFile};
 
 use super::{super::shared_fd::SharedFd, Op, OpAble};
 #[cfg(any(feature = "legacy", feature = "poll-io"))]
-use crate::driver::ready::Direction;
+use super::{driver::ready::Direction, MaybeFd};
 use crate::{
     buf::{IoBuf, IoVecBuf},
     BufResult,
@@ -25,7 +25,7 @@ macro_rules! write_result {
             impl<$T: $Trait> super::Op<$name<$T>> {
                 pub(crate) async fn result(self) -> BufResult<usize, $T> {
                     let complete = self.await;
-                    (complete.meta.result.map(|v| v as _), complete.data.$buf)
+                    (complete.meta.result.map(|v| v.into_inner() as _), complete.data.$buf)
                 }
             }
         )*
@@ -79,7 +79,7 @@ impl<T: IoBuf> OpAble for Write<T> {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(windows)]
         let fd = self.fd.as_raw_handle() as _;
         #[cfg(unix)]
@@ -128,7 +128,7 @@ impl<T: IoBuf> OpAble for WriteAt<T> {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(windows)]
         let fd = self.fd.as_raw_handle() as _;
         #[cfg(unix)]
@@ -181,7 +181,7 @@ impl<T: IoVecBuf> OpAble for WriteVec<T> {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         #[cfg(windows)]
         let fd = self.fd.as_raw_handle() as _;
         #[cfg(unix)]
@@ -237,7 +237,7 @@ impl<T: IoVecBuf> OpAble for WriteVecAt<T> {
     }
 
     #[cfg(any(feature = "legacy", feature = "poll-io"))]
-    fn legacy_call(&mut self) -> io::Result<u32> {
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
         write_vectored_at(
             self.fd.raw_fd(),
             self.buf_vec.read_iovec_ptr(),
@@ -255,21 +255,30 @@ pub(crate) mod impls {
     use crate::syscall_u32;
 
     /// A wrapper of [`libc::write`]
-    pub(crate) fn write(fd: i32, buf: *const u8, len: usize) -> io::Result<u32> {
-        syscall_u32!(write(fd, buf as _, len))
+    pub(crate) fn write(fd: i32, buf: *const u8, len: usize) -> io::Result<MaybeFd> {
+        syscall_u32!(write@NON_FD(fd, buf as _, len))
     }
 
     /// A wrapper of [`libc::write`]
-    pub(crate) fn write_at(fd: i32, buf: *const u8, len: usize, offset: u64) -> io::Result<u32> {
+    pub(crate) fn write_at(
+        fd: i32,
+        buf: *const u8,
+        len: usize,
+        offset: u64,
+    ) -> io::Result<MaybeFd> {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(pwrite(fd, buf as _, len, offset))
+        syscall_u32!(pwrite@NON_FD(fd, buf as _, len, offset))
     }
 
     /// A wrapper of [`libc::writev`]
-    pub(crate) fn write_vectored(fd: i32, buf_vec: *const iovec, len: usize) -> io::Result<u32> {
-        syscall_u32!(writev(fd, buf_vec as _, len as _))
+    pub(crate) fn write_vectored(
+        fd: i32,
+        buf_vec: *const iovec,
+        len: usize,
+    ) -> io::Result<MaybeFd> {
+        syscall_u32!(writev@NON_FD(fd, buf_vec as _, len as _))
     }
 
     /// A wrapper of [`libc::pwritev`]
@@ -278,11 +287,11 @@ pub(crate) mod impls {
         buf_vec: *const iovec,
         len: usize,
         offset: u64,
-    ) -> io::Result<u32> {
+    ) -> io::Result<MaybeFd> {
         let offset = libc::off_t::try_from(offset)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "offset too big"))?;
 
-        syscall_u32!(pwritev(fd, buf_vec as _, len as _, offset))
+        syscall_u32!(pwritev@NON_FD(fd, buf_vec as _, len as _, offset))
     }
 }
 

--- a/monoio/src/driver/poll.rs
+++ b/monoio/src/driver/poll.rs
@@ -1,6 +1,6 @@
 use std::{io, task::Context, time::Duration};
 
-use super::{ready::Direction, scheduled_io::ScheduledIo};
+use super::{op::MaybeFd, ready::Direction, scheduled_io::ScheduledIo};
 use crate::{driver::op::CompletionMeta, utils::slab::Slab};
 
 /// Poller with io dispatch.
@@ -77,7 +77,7 @@ impl Poll {
         cx: &mut Context<'_>,
         token: usize,
         direction: Direction,
-        syscall: impl FnOnce() -> io::Result<u32>,
+        syscall: impl FnOnce() -> io::Result<MaybeFd>,
     ) -> std::task::Poll<CompletionMeta> {
         let mut scheduled_io = self.io_dispatch.get(token).expect("scheduled_io lost");
         let ref_mut = scheduled_io.as_mut();

--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -45,7 +45,7 @@ impl State {
         // TODO: only Init state can convert?
         if matches!(state, UringState::Init) {
             let mut source = mio::unix::SourceFd(&fd);
-            crate::syscall!(fcntl(fd, libc::F_SETFL, libc::O_NONBLOCK))?;
+            crate::syscall!(fcntl@RAW(fd, libc::F_SETFL, libc::O_NONBLOCK))?;
             let reg = CURRENT
                 .with(|inner| match inner {
                     #[cfg(all(target_os = "linux", feature = "iouring"))]
@@ -58,7 +58,7 @@ impl State {
                     crate::driver::Inner::Legacy(_) => panic!("unexpected legacy runtime"),
                 })
                 .inspect_err(|_| {
-                    let _ = crate::syscall!(fcntl(fd, libc::F_SETFL, 0));
+                    let _ = crate::syscall!(fcntl@RAW(fd, libc::F_SETFL, 0));
                 })?;
             *state = UringState::Legacy(Some(reg));
         } else {
@@ -86,7 +86,7 @@ impl State {
             return Err(io::Error::new(io::ErrorKind::Other, "empty token"));
         };
         let mut source = mio::unix::SourceFd(&fd);
-        crate::syscall!(fcntl(fd, libc::F_SETFL, 0))?;
+        crate::syscall!(fcntl@RAW(fd, libc::F_SETFL, 0))?;
         CURRENT
             .with(|inner| match inner {
                 #[cfg(all(target_os = "linux", feature = "iouring"))]
@@ -97,7 +97,7 @@ impl State {
                 crate::driver::Inner::Legacy(_) => panic!("unexpected legacy runtime"),
             })
             .inspect_err(|_| {
-                let _ = crate::syscall!(fcntl(fd, libc::F_SETFL, libc::O_NONBLOCK));
+                let _ = crate::syscall!(fcntl@RAW(fd, libc::F_SETFL, libc::O_NONBLOCK));
             })?;
         *self = State::Uring(UringState::Init);
         Ok(())

--- a/monoio/src/fs/file/windows.rs
+++ b/monoio/src/fs/file/windows.rs
@@ -12,7 +12,7 @@ use windows_sys::Win32::Networking::WinSock::WSABUF;
 use super::File;
 use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
-    driver::{op::Op, shared_fd::SharedFd},
+    driver::shared_fd::SharedFd,
 };
 
 impl AsRawHandle for File {
@@ -45,13 +45,12 @@ mod blocking {
         let raw_bufs = buf_vec.write_wsabuf_ptr();
         let len = buf_vec.write_wsabuf_len();
 
-        // Safely wrap the raw pointers into a Vec, but prevent automatic cleanup with ManuallyDrop
-        let wasbufs = ManuallyDrop::new(unsafe { Vec::from_raw_parts(raw_bufs, len, len) });
+        let wsabufs = unsafe { std::slice::from_raw_parts(raw_bufs, len) };
 
         let mut total_bytes_read = 0;
 
         // Iterate through each WSABUF structure and read data into it
-        for wsabuf in wasbufs.iter() {
+        for wsabuf in wsabufs.iter() {
             // Safely create a Vec from the WSABUF pointer, then pass it to the read function
             let (res, _) = read(
                 fd.clone(),
@@ -83,7 +82,7 @@ mod blocking {
     }
 
     /// The `writev` implement on windows
-    ///  
+    ///
     /// Due to windows does not have syscall like `writev`, so we need to simulate it by ourself.
     ///
     /// This function is just to write each buffer into file by calling the `write` function.
@@ -95,8 +94,7 @@ mod blocking {
         let raw_bufs = buf_vec.read_wsabuf_ptr() as *mut WSABUF;
         let len = buf_vec.read_wsabuf_len();
 
-        // Safely wrap the raw pointers into a Vec, but prevent automatic cleanup with ManuallyDrop
-        let wsabufs = ManuallyDrop::new(unsafe { Vec::from_raw_parts(raw_bufs, len, len) });
+        let wsabufs = unsafe { std::slice::from_raw_parts(raw_bufs, len) };
         let mut total_bytes_write = 0;
 
         // Iterate through each WSABUF structure and write data from it
@@ -162,21 +160,18 @@ mod asyncified {
         let fd = fd.as_raw_handle() as _;
 
         let res = asyncify(move || {
-            // Safely wrap the raw pointers into a Vec, but prevent automatic cleanup with
-            // ManuallyDrop
-            let wasbufs = ManuallyDrop::new(unsafe {
-                Vec::from_raw_parts(raw_bufs as *mut WSABUF, len, len)
-            });
+            let wsabufs = unsafe { std::slice::from_raw_parts(raw_bufs as *mut WSABUF, len) };
 
             let mut total_bytes_read = 0;
 
             // Iterate through each WSABUF structure and read data into it
-            for wsabuf in wasbufs.iter() {
+            for wsabuf in wsabufs.iter() {
                 let res = read::read(fd, wsabuf.buf, wsabuf.len as usize);
 
                 // Handle the result of the read operation
                 match res {
                     Ok(bytes_read) => {
+                        let bytes_read = bytes_read.into_inner();
                         total_bytes_read += bytes_read;
                         // If fewer bytes were read than requested, stop further reads
                         if bytes_read < wsabuf.len {
@@ -203,7 +198,7 @@ mod asyncified {
     }
 
     /// The `writev` implement on windows
-    ///  
+    ///
     /// Due to windows does not have syscall like `writev`, so we need to simulate it by ourself.
     ///
     /// This function is just to write each buffer into file by calling the `write` function.
@@ -218,11 +213,7 @@ mod asyncified {
         let fd = fd.as_raw_handle() as _;
 
         let res = asyncify(move || {
-            // Safely wrap the raw pointers into a Vec, but prevent automatic cleanup with
-            // ManuallyDrop
-            let wsabufs = ManuallyDrop::new(unsafe {
-                Vec::from_raw_parts(raw_bufs as *mut WSABUF, len, len)
-            });
+            let wsabufs = unsafe { std::slice::from_raw_parts(raw_bufs as *mut WSABUF, len) };
 
             let mut total_bytes_write = 0;
 
@@ -231,6 +222,7 @@ mod asyncified {
 
                 match res {
                     Ok(bytes_write) => {
+                        let bytes_write = bytes_write.into_inner();
                         total_bytes_write += bytes_write;
                         if bytes_write < wsabuf.len {
                             break;

--- a/monoio/src/fs/mod.rs
+++ b/monoio/src/fs/mod.rs
@@ -125,7 +125,7 @@ macro_rules! asyncify_op {
 
             let res = $crate::fs::asyncify(move || $op(fd, buf_ptr as *mut _, len, $($extra_param)?))
                 .await
-                .map(|n| n as usize);
+                .map(|n| n.into_inner() as usize);
 
             unsafe { buf.set_init(*res.as_ref().unwrap_or(&0)) };
 
@@ -150,7 +150,7 @@ macro_rules! asyncify_op {
 
             let res = $crate::fs::asyncify(move || $op(fd, buf_ptr as *mut _, len, $($extra_param)?))
                 .await
-                .map(|n| n as usize);
+                .map(|n| n.into_inner() as usize);
 
             // unsafe { buf.set_init(*res.as_ref().unwrap_or(&0)) };
 

--- a/monoio/src/fs/mod.rs
+++ b/monoio/src/fs/mod.rs
@@ -36,7 +36,7 @@ pub use file_type::FileType;
 #[cfg(unix)]
 mod permissions;
 #[cfg(windows)]
-use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
+use std::os::windows::io::{AsRawHandle, FromRawHandle};
 
 #[cfg(unix)]
 pub use permissions::Permissions;
@@ -92,7 +92,7 @@ where
 macro_rules! uring_op {
     ($fn_name:ident<$trait_name:ident>($op_name: ident, $buf_name:ident $(, $pos:ident: $pos_type:ty)?)) => {
         pub(crate) async fn $fn_name<T: $trait_name>(fd: SharedFd, $buf_name: T, $($pos: $pos_type)?) -> $crate::BufResult<usize, T> {
-            let op = Op::$op_name(fd, $buf_name, $($pos)?).unwrap();
+            let op = $crate::driver::op::Op::$op_name(fd, $buf_name, $($pos)?).unwrap();
             op.result().await
         }
     };

--- a/monoio/src/fs/open_options.rs
+++ b/monoio/src/fs/open_options.rs
@@ -352,7 +352,7 @@ impl OpenOptions {
 
         // The file is open
         Ok(File::from_shared_fd(SharedFd::new_without_register(
-            completion.meta.result? as _,
+            completion.meta.result?.into_inner() as _,
         )))
     }
 

--- a/monoio/src/net/mod.rs
+++ b/monoio/src/net/mod.rs
@@ -53,12 +53,12 @@ pub(crate) fn new_socket(
     // Gives a warning for platforms without SOCK_NONBLOCK.
     #[allow(clippy::let_and_return)]
     #[cfg(unix)]
-    let socket = crate::syscall!(socket(domain, socket_type, 0));
+    let socket = crate::syscall!(socket@RAW(domain, socket_type, 0));
 
     // Mimic `libstd` and set `SO_NOSIGPIPE` on apple systems.
     #[cfg(target_vendor = "apple")]
     let socket = socket.and_then(|socket| {
-        crate::syscall!(setsockopt(
+        crate::syscall!(setsockopt@RAW(
             socket,
             libc::SOL_SOCKET,
             libc::SO_NOSIGPIPE,
@@ -73,14 +73,14 @@ pub(crate) fn new_socket(
     let socket = socket.and_then(|socket| {
         // For platforms that don't support flags in socket, we need to
         // set the flags ourselves.
-        crate::syscall!(fcntl(socket, libc::F_SETFL, libc::O_NONBLOCK))
+        crate::syscall!(fcntl@RAW(socket, libc::F_SETFL, libc::O_NONBLOCK))
             .and_then(|_| {
-                crate::syscall!(fcntl(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| socket)
+                crate::syscall!(fcntl@RAW(socket, libc::F_SETFD, libc::FD_CLOEXEC)).map(|_| socket)
             })
             .inspect_err(|_| {
                 // If either of the `fcntl` calls failed, ensure the socket is
                 // closed and return the error.
-                let _ = crate::syscall!(close(socket));
+                let _ = crate::syscall!(close@RAW(socket));
             })
     });
 
@@ -100,17 +100,17 @@ pub(crate) fn new_socket(
     socket_type: WINSOCK_SOCKET_TYPE,
 ) -> std::io::Result<RawSocket> {
     let _: i32 = crate::syscall!(
-        WSAStartup(MAKEWORD(2, 2), std::ptr::null_mut()),
+        WSAStartup@RAW(MAKEWORD(2, 2), std::ptr::null_mut()),
         PartialEq::eq,
         NO_ERROR as _
     )?;
     let socket = crate::syscall!(
-        socket(domain as _, socket_type, 0),
+        socket@RAW(domain as _, socket_type, 0),
         PartialEq::eq,
         INVALID_SOCKET
     )?;
     crate::syscall!(
-        ioctlsocket(socket, FIONBIO, &mut 1),
+        ioctlsocket@RAW(socket, FIONBIO, &mut 1),
         PartialEq::ne,
         NO_ERROR as _
     )

--- a/monoio/src/net/tcp/listener.rs
+++ b/monoio/src/net/tcp/listener.rs
@@ -117,7 +117,7 @@ impl TcpListener {
         let fd = completion.meta.result?;
 
         // Construct stream
-        let stream = TcpStream::from_shared_fd(SharedFd::new::<false>(fd as _)?);
+        let stream = TcpStream::from_shared_fd(SharedFd::new::<false>(fd.into_inner() as _)?);
 
         // Construct SocketAddr
         let storage = completion.data.addr.0.as_ptr();
@@ -174,7 +174,7 @@ impl TcpListener {
         let fd = completion.meta.result?;
 
         // Construct stream
-        let stream = TcpStream::from_shared_fd(SharedFd::new::<false>(fd as _)?);
+        let stream = TcpStream::from_shared_fd(SharedFd::new::<false>(fd.into_inner() as _)?);
 
         // Construct SocketAddr
         let storage = completion.data.addr.0.as_ptr();

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -473,6 +473,7 @@ impl tokio::io::AsyncRead for TcpStream {
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut recv, cx));
 
             std::task::Poll::Ready(ret.result.map(|n| {
+                let n = n.into_inner();
                 buf.assume_init(n as usize);
                 buf.advance(n as usize);
             }))
@@ -492,7 +493,7 @@ impl tokio::io::AsyncWrite for TcpStream {
             let mut send = Op::send_raw(&self.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut send, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 
@@ -526,7 +527,7 @@ impl tokio::io::AsyncWrite for TcpStream {
             let mut writev = Op::writev_raw(&self.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut writev, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 

--- a/monoio/src/net/tcp/stream_poll.rs
+++ b/monoio/src/net/tcp/stream_poll.rs
@@ -76,6 +76,7 @@ impl tokio::io::AsyncRead for TcpStreamPoll {
             let ret = ready!(crate::driver::op::PollLegacy::poll_io(&mut recv, cx));
 
             std::task::Poll::Ready(ret.result.map(|n| {
+                let n = n.into_inner();
                 buf.assume_init(n as usize);
                 buf.advance(n as usize);
             }))
@@ -95,7 +96,7 @@ impl tokio::io::AsyncWrite for TcpStreamPoll {
             let mut send = Op::send_raw(&self.0.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_io(&mut send, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 
@@ -134,7 +135,7 @@ impl tokio::io::AsyncWrite for TcpStreamPoll {
             let mut writev = Op::writev_raw(&self.0.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_io(&mut writev, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 

--- a/monoio/src/net/tcp/tfo/linux.rs
+++ b/monoio/src/net/tcp/tfo/linux.rs
@@ -11,7 +11,7 @@ thread_local! {
 
 /// Call before listen.
 pub(crate) fn set_tcp_fastopen<S: AsRawFd>(fd: &S, fast_open: i32) -> io::Result<()> {
-    crate::syscall!(setsockopt(
+    crate::syscall!(setsockopt@RAW(
         fd.as_raw_fd(),
         libc::SOL_TCP,
         libc::TCP_FASTOPEN,
@@ -26,7 +26,7 @@ pub(crate) fn set_tcp_fastopen<S: AsRawFd>(fd: &S, fast_open: i32) -> io::Result
 pub(crate) fn set_tcp_fastopen_connect<S: AsRawFd>(fd: &S) -> io::Result<()> {
     const ENABLED: libc::c_int = 0x1;
 
-    crate::syscall!(setsockopt(
+    crate::syscall!(setsockopt@RAW(
         fd.as_raw_fd(),
         libc::SOL_TCP,
         libc::TCP_FASTOPEN_CONNECT,

--- a/monoio/src/net/tcp/tfo/macos.rs
+++ b/monoio/src/net/tcp/tfo/macos.rs
@@ -3,7 +3,7 @@ use std::{io, os::fd::AsRawFd};
 /// Call before listen.
 pub(crate) fn set_tcp_fastopen<S: AsRawFd>(fd: &S) -> io::Result<()> {
     const ENABLED: libc::c_int = 0x1;
-    crate::syscall!(setsockopt(
+    crate::syscall!(setsockopt@RAW(
         fd.as_raw_fd(),
         libc::IPPROTO_TCP,
         libc::TCP_FASTOPEN,
@@ -19,7 +19,7 @@ pub(crate) fn set_tcp_fastopen_force_enable<S: AsRawFd>(fd: &S) -> io::Result<()
     const TCP_FASTOPEN_FORCE_ENABLE: libc::c_int = 0x218;
     const ENABLED: libc::c_int = 0x1;
 
-    crate::syscall!(setsockopt(
+    crate::syscall!(setsockopt@RAW(
         fd.as_raw_fd(),
         libc::IPPROTO_TCP,
         TCP_FASTOPEN_FORCE_ENABLE,

--- a/monoio/src/net/unix/listener.rs
+++ b/monoio/src/net/unix/listener.rs
@@ -75,7 +75,7 @@ impl UnixListener {
         let fd = completion.meta.result?;
 
         // Construct stream
-        let stream = UnixStream::from_shared_fd(SharedFd::new::<false>(fd as _)?);
+        let stream = UnixStream::from_shared_fd(SharedFd::new::<false>(fd.into_inner() as _)?);
 
         // Construct SocketAddr
         let mut storage = unsafe { std::mem::MaybeUninit::assume_init(completion.data.addr.0) };
@@ -105,7 +105,7 @@ impl UnixListener {
         let fd = completion.meta.result?;
 
         // Construct stream
-        let stream = UnixStream::from_shared_fd(SharedFd::new::<false>(fd as _)?);
+        let stream = UnixStream::from_shared_fd(SharedFd::new::<false>(fd.into_inner() as _)?);
 
         // Construct SocketAddr
         let mut storage = unsafe { std::mem::MaybeUninit::assume_init(completion.data.addr.0) };

--- a/monoio/src/net/unix/pipe.rs
+++ b/monoio/src/net/unix/pipe.rs
@@ -30,8 +30,8 @@ pub fn new_pipe() -> io::Result<(Pipe, Pipe)> {
         }
     };
     #[cfg(target_os = "linux")]
-    crate::syscall!(pipe2(pipes.as_mut_ptr() as _, flag))?;
+    crate::syscall!(pipe2@RAW(pipes.as_mut_ptr() as _, flag))?;
     #[cfg(not(target_os = "linux"))]
-    crate::syscall!(pipe(pipes.as_mut_ptr() as _))?;
+    crate::syscall!(pipe@RAW(pipes.as_mut_ptr() as _))?;
     Ok((Pipe::from_raw_fd(pipes[0]), Pipe::from_raw_fd(pipes[1])))
 }

--- a/monoio/src/net/unix/seq_packet/listener.rs
+++ b/monoio/src/net/unix/seq_packet/listener.rs
@@ -26,8 +26,8 @@ impl UnixSeqpacketListener {
     pub fn bind_with_backlog<P: AsRef<Path>>(path: P, backlog: libc::c_int) -> io::Result<Self> {
         let (addr, addr_len) = socket_addr(path.as_ref())?;
         let socket = new_socket(libc::AF_UNIX, libc::SOCK_SEQPACKET)?;
-        crate::syscall!(bind(socket, &addr as *const _ as *const _, addr_len))?;
-        crate::syscall!(listen(socket, backlog))?;
+        crate::syscall!(bind@RAW(socket, &addr as *const _ as *const _, addr_len))?;
+        crate::syscall!(listen@RAW(socket, backlog))?;
         Ok(Self {
             fd: SharedFd::new::<false>(socket)?,
         })
@@ -50,7 +50,7 @@ impl UnixSeqpacketListener {
         let fd = completion.meta.result?;
 
         // Construct stream
-        let stream = UnixSeqpacket::from_shared_fd(SharedFd::new::<false>(fd as _)?);
+        let stream = UnixSeqpacket::from_shared_fd(SharedFd::new::<false>(fd.into_inner() as _)?);
 
         // Construct SocketAddr
         let mut storage = unsafe { std::mem::MaybeUninit::assume_init(completion.data.addr.0) };

--- a/monoio/src/net/unix/socket_addr.rs
+++ b/monoio/src/net/unix/socket_addr.rs
@@ -233,15 +233,15 @@ where
     };
 
     let mut fds = [-1; 2];
-    crate::syscall!(socketpair(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
+    crate::syscall!(socketpair@RAW(libc::AF_UNIX, flags, 0, fds.as_mut_ptr()))?;
     let pair = unsafe { (T::from_raw_fd(fds[0]), T::from_raw_fd(fds[1])) };
     Ok(pair)
 }
 
 pub(crate) fn local_addr(socket: RawFd) -> io::Result<SocketAddr> {
-    SocketAddr::new(|sockaddr, socklen| crate::syscall!(getsockname(socket, sockaddr, socklen)))
+    SocketAddr::new(|sockaddr, socklen| crate::syscall!(getsockname@RAW(socket, sockaddr, socklen)))
 }
 
 pub(crate) fn peer_addr(socket: RawFd) -> io::Result<SocketAddr> {
-    SocketAddr::new(|sockaddr, socklen| crate::syscall!(getpeername(socket, sockaddr, socklen)))
+    SocketAddr::new(|sockaddr, socklen| crate::syscall!(getpeername@RAW(socket, sockaddr, socklen)))
 }

--- a/monoio/src/net/unix/stream.rs
+++ b/monoio/src/net/unix/stream.rs
@@ -323,6 +323,7 @@ impl tokio::io::AsyncRead for UnixStream {
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut recv, cx));
 
             std::task::Poll::Ready(ret.result.map(|n| {
+                let n = n.into_inner();
                 buf.assume_init(n as usize);
                 buf.advance(n as usize);
             }))
@@ -342,7 +343,7 @@ impl tokio::io::AsyncWrite for UnixStream {
             let mut send = Op::send_raw(&self.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_legacy(&mut send, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 

--- a/monoio/src/net/unix/stream_poll.rs
+++ b/monoio/src/net/unix/stream_poll.rs
@@ -65,6 +65,7 @@ impl tokio::io::AsyncRead for UnixStreamPoll {
             let ret = ready!(crate::driver::op::PollLegacy::poll_io(&mut recv, cx));
 
             std::task::Poll::Ready(ret.result.map(|n| {
+                let n = n.into_inner();
                 buf.assume_init(n as usize);
                 buf.advance(n as usize);
             }))
@@ -84,7 +85,7 @@ impl tokio::io::AsyncWrite for UnixStreamPoll {
             let mut send = Op::send_raw(&self.0.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_io(&mut send, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 
@@ -121,7 +122,7 @@ impl tokio::io::AsyncWrite for UnixStreamPoll {
             let mut writev = Op::writev_raw(&self.0.fd, raw_buf);
             let ret = ready!(crate::driver::op::PollLegacy::poll_io(&mut writev, cx));
 
-            std::task::Poll::Ready(ret.result.map(|n| n as usize))
+            std::task::Poll::Ready(ret.result.map(|n| n.into_inner() as usize))
         }
     }
 

--- a/monoio/tests/fd_leak.rs
+++ b/monoio/tests/fd_leak.rs
@@ -1,0 +1,105 @@
+use std::{
+    io::{Read, Write},
+    sync::mpsc::channel,
+    time::Duration,
+};
+
+use monoio::io::AsyncReadRentExt;
+
+// This test is used to prove the runtime can close the cancelled(but failed to cancel) op's fd
+// result.
+// 1. accept(push accept op) and poll the future to Pending
+// 2. spawn another thread to connect the listener(will start connecting after task drop)
+// 3. cancel(drop) the accept task
+// 4. spin for a while to delay the iouring enter which submit the cancel op
+// 5. the other thread should be able to get a connection
+// 6. if the other thread can read eof, then it can prove the runtime close the fd correctly
+// 7. if the read blocked, then the runtime failed to close the fd
+#[monoio::test_all(timer_enabled = true)]
+async fn test_fd_leak_cancel_fail() {
+    // step 1 and 2
+    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let mut incoming = listener.accept();
+    let fut = unsafe { std::pin::Pin::new_unchecked(&mut incoming) };
+    assert!(monoio::select! {
+        result = fut => Ok(result),
+        _ = monoio::time::sleep(Duration::from_millis(200)) => Err(()),
+    }
+    .is_err());
+
+    // step 2
+    let (tx1, rx1) = channel::<()>();
+    let (tx2, rx2) = channel::<()>();
+    std::thread::spawn(move || {
+        rx1.recv().unwrap();
+        // step 5
+        let mut conn = std::net::TcpStream::connect(addr).unwrap();
+        tx2.send(()).unwrap();
+        let mut buf = [0u8; 1];
+        conn.write_all(&buf).unwrap();
+        // step 6
+        let ret = conn.read(&mut buf[..]);
+        assert!(
+            matches!(ret, Ok(0))
+                || matches!(ret, Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset)
+        );
+        tx2.send(()).unwrap();
+    });
+
+    // step 3: cancel the accept op but not submit the cancel op
+    drop(incoming);
+    tx1.send(()).unwrap();
+    // step 4: block the thread with sync channel
+    rx2.recv().unwrap();
+    // step 7: wait for 1 second to make sure the runtime can close the fd
+    monoio::time::sleep(Duration::from_secs(1)).await;
+
+    if rx2.try_recv().is_ok() {
+        // With iouring, the fd is accepted and closed by the runtime.
+        // So here it will return.
+        return;
+    }
+    // With legacy driver, the accept syscall is not executed.
+    // So we can accept now and check if it is the connection established by the other thread.
+    // We can read 1 byte to check if it is zero. Then we close the fd and wait for the other
+    // thread.
+    // So we can prove the connection at server side is either not accepted or closed by the
+    // runtime.
+    let (mut conn, _) = listener.accept().await.unwrap();
+    let buf = vec![1; 1];
+    let (r, buf) = conn.read_exact(buf).await;
+    assert_eq!(r.unwrap(), 1);
+    assert_eq!(buf[0], 0);
+    drop(conn);
+    rx2.recv().unwrap();
+}
+
+// This test is used to prove the runtime try best to cancel pending op when op is dropped.
+#[cfg(feature = "async-cancel")]
+#[monoio::test_all(timer_enabled = true)]
+async fn test_fd_leak_try_cancel() {
+    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = listener.accept();
+    assert!(monoio::select! {
+        result = incoming => Ok(result),
+        _ = monoio::time::sleep(Duration::from_millis(200)) => Err(()),
+    }
+    .is_err());
+    // The future is dropped now and the cancel op is pushed.
+    monoio::time::sleep(Duration::from_millis(200)).await;
+    let (tx, rx) = channel::<()>();
+    std::thread::spawn(move || {
+        let mut conn = std::net::TcpStream::connect(addr).unwrap();
+        let buf = [0u8; 1];
+        conn.write_all(&buf).unwrap();
+        tx.send(()).unwrap();
+    });
+    rx.recv().unwrap();
+    let mut conn = listener.accept().await.unwrap().0;
+    let buf = vec![1; 1];
+    let (r, buf) = conn.read_exact(buf).await;
+    assert_eq!(r.unwrap(), 1);
+    assert_eq!(buf[0], 0);
+}


### PR DESCRIPTION
# What Problem This PR Fixed
In a readiness-based synchronous non-blocking I/O model, canceling a pending I/O call is side-effect-free because the syscall hasn’t actually been executed. In other words, the syscall’s execution state is definitive: it has either been executed or not, with no intermediate state (such as “in execution”).

However, with asynchronous I/O like io-uring, canceling I/O and executing I/O are no longer mutually exclusive. When canceling an I/O operation, it may either be successfully canceled or already completed.

Previously, we used traits like AsyncReadRent/AsyncWriteRent, which transfer buffer ownership, to address buffer memory safety. When a Future is dropped (indicating I/O cancellation), the buffer is transferred to a global state and only cleaned up when the corresponding CQE returns.

I also designed a CancellableIO trait, which works by first pushing a CancelOp when canceling cancellable I/O and then awaiting the original Op’s CQE, expecting it to return with either a cancellation success or the syscall result within a short timeframe.

For standard I/O interfaces, when cancellation occurs, the runtime will push a CancelOp. However, this alone is insufficient: CancelOp does not guarantee that the Op is canceled. If the Op returns a file descriptor (fd), we cannot ignore the possibility of a failed cancellation. Similar to the previous solutions, we need to await the Op result and close its corresponding fd.

# Solution
Once we get fd from the kernel, convert it to a wrapped type instantly, and this wrapped type can guarntee the fd is closed when dropped.

How to know if the result in the CQE is fd? We can only know it with `user_data`. Since a slab lookup is essential, saving a is_fd mark inside is the cheapest way I can think about. One may think about putting logic inside the op related bottom half, but in this way fd may leak if the future not be polled. We can only wrap it with RAII when calling `tick`, which means a runtime cost is unavoidable.

# Affected Cases
Accept and Open op are affected. If users use these ops with timeout(note the timeout may also allpied to the outer layer future), or with any style which not poll the op until ready, and use io_uring as the backend, then they may be affected, there may be fd leaks when the future cancelled.

epoll/kqueue/iocp backends are not affected.

# Further reading
@ethe wrote an article explains this issue in more detail: [Async Rust is not safe with io_uring](https://tonbo.io/blog/async-rust-is-not-safe-with-io-uring)

# Additional Notes
This PR also fixed another minor issue.
Some background:
1. When close fd, with io_uring backend, it will submit a Close Op and leave without waiting.
2. When Op drops, it will remove its related state. And if the state is unfinished and `async-cancel` feature is enabled, the runtime will try to cancel the op by pushing a AsyncCancel op.

Problem: The close op will be cancelled because of dropped, which is not what we want.
Solution: So I added a const bool for each op to hint if the cancel is desired(intended leaving without waiting or not want the op executed any more). For Close op, it is false and for others like Read op, it is true.