### PR TITLE
fix: re-registering interest on Windows (#274)

### DIFF
--- a/monoio/src/driver/legacy/iocp/state.rs
+++ b/monoio/src/driver/legacy/iocp/state.rs
@@ -25,20 +25,27 @@ pub enum SockPollStatus {
 }
 
 #[derive(Debug)]
-pub struct SocketState {
-    pub socket: RawSocket,
+pub struct SocketStateInner {
     pub inner: Option<Pin<Arc<Mutex<SockState>>>>,
     pub token: mio::Token,
     pub interest: mio::Interest,
+}
+
+#[derive(Debug)]
+pub struct SocketState {
+    pub socket: RawSocket,
+    pub inner: Arc<Mutex<SocketStateInner>>,
 }
 
 impl SocketState {
     pub fn new(socket: RawSocket) -> Self {
         Self {
             socket,
-            inner: None,
-            token: mio::Token(0),
-            interest: mio::Interest::READABLE,
+            inner: Arc::new(Mutex::new(SocketStateInner {
+                inner: None,
+                token: mio::Token(0),
+                interest: mio::Interest::READABLE,
+            })),
         }
     }
 }

--- a/monoio/src/driver/scheduled_io.rs
+++ b/monoio/src/driver/scheduled_io.rs
@@ -9,8 +9,12 @@ pub(crate) struct ScheduledIo {
     reader: Option<Waker>,
     /// Waker used for AsyncWrite.
     writer: Option<Waker>,
+
+    #[cfg(windows)]
+    pub state: std::sync::Arc<std::sync::Mutex<super::legacy::iocp::SocketStateInner>>,
 }
 
+#[cfg(not(windows))]
 impl Default for ScheduledIo {
     #[inline]
     fn default() -> Self {
@@ -19,11 +23,17 @@ impl Default for ScheduledIo {
 }
 
 impl ScheduledIo {
-    pub(crate) const fn new() -> Self {
+    pub(crate) const fn new(
+        #[cfg(windows)] state: std::sync::Arc<
+            std::sync::Mutex<super::legacy::iocp::SocketStateInner>,
+        >,
+    ) -> Self {
         Self {
             readiness: Ready::EMPTY,
             reader: None,
             writer: None,
+            #[cfg(windows)]
+            state,
         }
     }
 


### PR DESCRIPTION
This PR fixes #274 by re-registering interest, allowing sockets to wake up the task again when ready.

Given monoio is thread-per-core, the code here is sub-optimal as it uses an Arc and locking primitives where it's not needed, this was done to keep the code similar to the rest of the IOCP related code. Eventually I plan to clean up the Windows legacy driver when I have free time, if it is not already cleaned up by someone else.