### PR TITLE
feat: Implement AsyncReadRent/WriteRent for std in-memory types

### DIFF
--- a/monoio/src/io/async_read_rent.rs
+++ b/monoio/src/io/async_read_rent.rs
@@ -74,14 +74,17 @@ impl<A: ?Sized + AsyncReadRent> AsyncReadRent for &mut A {
 
 impl AsyncReadRent for &[u8] {
     fn read<T: IoBufMut>(&mut self, mut buf: T) -> impl Future<Output = BufResult<usize, T>> {
-        let amt = std::cmp::min(self.len(), buf.bytes_total());
-        let (a, b) = self.split_at(amt);
+        let buf_capacity = buf.bytes_total();
+        let available = self.len();
+        let to_read = std::cmp::min(available, buf_capacity);
+        let (prefix, remainder) = self.split_at(to_read);
         unsafe {
-            buf.write_ptr().copy_from_nonoverlapping(a.as_ptr(), amt);
-            buf.set_init(amt);
+            let dst = buf.write_ptr();
+            dst.copy_from_nonoverlapping(prefix.as_ptr(), to_read);
+            buf.set_init(to_read);
         }
-        *self = b;
-        std::future::ready((Ok(amt), buf))
+        *self = remainder;
+        std::future::ready((Ok(to_read), buf))
     }
 
     fn readv<T: IoVecBufMut>(&mut self, mut buf: T) -> impl Future<Output = BufResult<usize, T>> {
@@ -101,20 +104,20 @@ impl AsyncReadRent for &[u8] {
                 #[cfg(unix)]
                 let amt = std::cmp::min(self.len(), buf.iov_len);
 
-                let (a, b) = self.split_at(amt);
+                let (prefix, remainder) = self.split_at(amt);
                 // # Safety
                 // The pointer is valid.
                 unsafe {
                     #[cfg(windows)]
                     buf.buf
                         .cast::<u8>()
-                        .copy_from_nonoverlapping(a.as_ptr(), amt);
+                        .copy_from_nonoverlapping(prefix.as_ptr(), amt);
                     #[cfg(unix)]
                     buf.iov_base
                         .cast::<u8>()
-                        .copy_from_nonoverlapping(a.as_ptr(), amt);
+                        .copy_from_nonoverlapping(prefix.as_ptr(), amt);
                 }
-                *self = b;
+                *self = remainder;
                 sum += amt;
 
                 if self.is_empty() {
@@ -130,18 +133,22 @@ impl AsyncReadRent for &[u8] {
 
 impl AsyncReadRent for &mut [u8] {
     fn read<T: IoBufMut>(&mut self, mut buf: T) -> impl Future<Output = BufResult<usize, T>> {
-        let amt = std::cmp::min(self.len(), buf.bytes_total());
-        let (a_ptr, b_ptr, b_len) = {
-            let ptr = self.as_mut_ptr();
-            let len = self.len();
-            (ptr, unsafe { ptr.add(amt) }, len - amt)
-        };
+        // Determine how many bytes to read
+        let buf_capacity = buf.bytes_total();
+        let available = self.len();
+        let to_read = std::cmp::min(available, buf_capacity);
+        // Pointers to the source and remaining data
+        let src_ptr = self.as_mut_ptr();
+        let next_ptr = unsafe { src_ptr.add(to_read) };
+        let remaining_len = available - to_read;
         unsafe {
-            buf.write_ptr().copy_from_nonoverlapping(a_ptr, amt);
-            buf.set_init(amt);
-            *self = std::slice::from_raw_parts_mut(b_ptr, b_len);
+            let dst = buf.write_ptr();
+            dst.copy_from_nonoverlapping(src_ptr, to_read);
+            buf.set_init(to_read);
+            // Update self to the remaining slice
+            *self = std::slice::from_raw_parts_mut(next_ptr, remaining_len);
         }
-        std::future::ready((Ok(amt), buf))
+        std::future::ready((Ok(to_read), buf))
     }
 
     fn readv<T: IoVecBufMut>(&mut self, mut buf: T) -> impl Future<Output = BufResult<usize, T>> {
@@ -161,19 +168,19 @@ impl AsyncReadRent for &mut [u8] {
                 #[cfg(unix)]
                 let amt = std::cmp::min(self.len(), buf.iov_len);
 
-                let (a_ptr, b_ptr, b_len) = {
-                    let ptr = self.as_mut_ptr();
-                    let len = self.len();
-                    (ptr, unsafe { ptr.add(amt) }, len - amt)
-                };
+                // Compute source and remaining pointers for this chunk
+                let src_ptr = self.as_mut_ptr();
+                let next_ptr = unsafe { src_ptr.add(amt) };
+                let remaining_len = self.len() - amt;
                 unsafe {
                     #[cfg(windows)]
-                    buf.buf.cast::<u8>().copy_from_nonoverlapping(a_ptr, amt);
+                    buf.buf.cast::<u8>().copy_from_nonoverlapping(src_ptr, amt);
                     #[cfg(unix)]
                     buf.iov_base
                         .cast::<u8>()
-                        .copy_from_nonoverlapping(a_ptr, amt);
-                    *self = std::slice::from_raw_parts_mut(b_ptr, b_len);
+                        .copy_from_nonoverlapping(src_ptr, amt);
+                    // Update self to the remaining slice
+                    *self = std::slice::from_raw_parts_mut(next_ptr, remaining_len);
                 }
                 sum += amt;
 

--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -1,6 +1,7 @@
-use std::future::Future;
-use std::io::Cursor;
-use std::io::Write;
+use std::{
+    future::Future,
+    io::{Cursor, Write},
+};
 
 use crate::{
     buf::{IoBuf, IoVecBuf},

--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -1,4 +1,6 @@
 use std::future::Future;
+use std::io::Cursor;
+use std::io::Write;
 
 use crate::{
     buf::{IoBuf, IoVecBuf},
@@ -116,6 +118,57 @@ impl<A: ?Sized + AsyncWriteRent> AsyncWriteRent for &mut A {
     }
 }
 
+#[cfg(unix)]
+fn iovecs_to_slices(iov_ptr: *const libc::iovec, iov_len: usize) -> Vec<&'static [u8]> {
+    unsafe {
+        std::slice::from_raw_parts(iov_ptr, iov_len)
+            .iter()
+            .map(|iov| std::slice::from_raw_parts(iov.iov_base as *const u8, iov.iov_len))
+            .collect()
+    }
+}
+
+#[cfg(windows)]
+fn wsabufs_to_slices(
+    wsabuf_ptr: *const windows_sys::Win32::Networking::WinSock::WSABUF,
+    wsabuf_len: usize,
+) -> Vec<&'static [u8]> {
+    unsafe {
+        std::slice::from_raw_parts(wsabuf_ptr, wsabuf_len)
+            .iter()
+            .map(|wsabuf| std::slice::from_raw_parts(wsabuf.buf as *const u8, wsabuf.len as usize))
+            .collect()
+    }
+}
+
+// Helper function for cursor writev logic
+fn cursor_writev_logic<C, T>(writer: &mut C, buf_vec: T) -> BufResult<usize, T>
+where
+    C: std::io::Write + ?Sized, // The writer needs to implement std::io::Write
+    T: IoVecBuf,
+{
+    #[cfg(unix)]
+    {
+        let iovecs = iovecs_to_slices(buf_vec.read_iovec_ptr(), buf_vec.read_iovec_len());
+        let iovec_refs: Vec<std::io::IoSlice<'_>> =
+            iovecs.iter().map(|s| std::io::IoSlice::new(s)).collect();
+        match std::io::Write::write_vectored(writer, &iovec_refs) {
+            Ok(n) => (Ok(n), buf_vec),
+            Err(e) => (Err(e), buf_vec),
+        }
+    }
+    #[cfg(windows)]
+    {
+        let wsabufs = wsabufs_to_slices(buf_vec.read_wsabuf_ptr(), buf_vec.read_wsabuf_len());
+        let iovec_refs: Vec<std::io::IoSlice<'_>> =
+            wsabufs.iter().map(|s| std::io::IoSlice::new(s)).collect();
+        match std::io::Write::write_vectored(writer, &iovec_refs) {
+            Ok(n) => (Ok(n), buf_vec),
+            Err(e) => (Err(e), buf_vec),
+        }
+    }
+}
+
 impl AsyncWriteRent for Vec<u8> {
     fn write<T: IoBuf>(&mut self, buf: T) -> impl Future<Output = BufResult<usize, T>> {
         let slice = buf.as_slice();
@@ -124,38 +177,35 @@ impl AsyncWriteRent for Vec<u8> {
         std::future::ready((Ok(len), buf))
     }
 
-    fn writev<T: IoVecBuf>(&mut self, buf: T) -> impl Future<Output = BufResult<usize, T>> {
-        let mut sum = 0;
+    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> impl Future<Output = BufResult<usize, T>> {
+        #[cfg(unix)]
         {
-            #[cfg(windows)]
-            let buf_slice =
-                unsafe { std::slice::from_raw_parts(buf.read_wsabuf_ptr(), buf.read_wsabuf_len()) };
-            #[cfg(unix)]
-            let buf_slice =
-                unsafe { std::slice::from_raw_parts(buf.read_iovec_ptr(), buf.read_iovec_len()) };
-            for buf in buf_slice {
-                #[cfg(windows)]
-                let len = buf.len as usize;
-                #[cfg(unix)]
-                let len = buf.iov_len;
-
-                sum += len;
+            let iovecs = unsafe {
+                std::slice::from_raw_parts(buf_vec.read_iovec_ptr(), buf_vec.read_iovec_len())
+            };
+            let total_len: usize = iovecs.iter().map(|iov| iov.iov_len).sum();
+            self.reserve(total_len);
+            let mut written = 0;
+            for slice in iovecs_to_slices(buf_vec.read_iovec_ptr(), buf_vec.read_iovec_len()) {
+                self.extend_from_slice(slice);
+                written += slice.len();
             }
-            self.reserve(sum);
-            for buf in buf_slice {
-                #[cfg(windows)]
-                let ptr = buf.buf.cast::<u8>();
-                #[cfg(unix)]
-                let ptr = buf.iov_base.cast::<u8>();
-                #[cfg(windows)]
-                let len = buf.len as usize;
-                #[cfg(unix)]
-                let len = buf.iov_len;
-
-                self.extend_from_slice(unsafe { std::slice::from_raw_parts(ptr, len) });
-            }
+            std::future::ready((Ok(written), buf_vec))
         }
-        std::future::ready((Ok(sum), buf))
+        #[cfg(windows)]
+        {
+            let wsabufs = unsafe {
+                std::slice::from_raw_parts(buf_vec.read_wsabuf_ptr(), buf_vec.read_wsabuf_len())
+            };
+            let total_len: usize = wsabufs.iter().map(|wsabuf| wsabuf.len as usize).sum();
+            self.reserve(total_len);
+            let mut written = 0;
+            for slice in wsabufs_to_slices(buf_vec.read_wsabuf_ptr(), buf_vec.read_wsabuf_len()) {
+                self.extend_from_slice(slice);
+                written += slice.len();
+            }
+            std::future::ready((Ok(written), buf_vec))
+        }
     }
 
     #[inline]
@@ -166,5 +216,127 @@ impl AsyncWriteRent for Vec<u8> {
     #[inline]
     fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
         std::future::ready(Ok(()))
+    }
+}
+
+impl AsyncWriteRent for Cursor<&mut Vec<u8>> {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        let slice = buf.as_slice();
+        match Write::write(self, slice) {
+            Ok(n) => (Ok(n), buf),
+            Err(e) => (Err(e), buf),
+        }
+    }
+
+    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> impl Future<Output = BufResult<usize, T>> {
+        std::future::ready(cursor_writev_logic(self, buf_vec))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        std::future::ready(Write::flush(self))
+    }
+
+    #[inline]
+    fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        // Cursor is in-memory, flush is a no-op, so shutdown is also a no-op.
+        std::future::ready(Ok(()))
+    }
+}
+
+impl AsyncWriteRent for Cursor<&mut [u8]> {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        let slice = buf.as_slice();
+        match Write::write(self, slice) {
+            Ok(n) => (Ok(n), buf),
+            Err(e) => (Err(e), buf),
+        }
+    }
+
+    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> impl Future<Output = BufResult<usize, T>> {
+        std::future::ready(cursor_writev_logic(self, buf_vec))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        std::future::ready(Write::flush(self))
+    }
+
+    #[inline]
+    fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        // Cursor is in-memory, flush is a no-op, so shutdown is also a no-op.
+        std::future::ready(Ok(()))
+    }
+}
+
+impl AsyncWriteRent for Cursor<Box<[u8]>> {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        let slice = buf.as_slice();
+        match Write::write(self, slice) {
+            Ok(n) => (Ok(n), buf),
+            Err(e) => (Err(e), buf),
+        }
+    }
+
+    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> impl Future<Output = BufResult<usize, T>> {
+        std::future::ready(cursor_writev_logic(self, buf_vec))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        std::future::ready(Write::flush(self))
+    }
+
+    #[inline]
+    fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        // Cursor is in-memory, flush is a no-op, so shutdown is also a no-op.
+        std::future::ready(Ok(()))
+    }
+}
+
+impl AsyncWriteRent for Cursor<Vec<u8>> {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        let slice = buf.as_slice();
+        match Write::write(self, slice) {
+            Ok(n) => (Ok(n), buf),
+            Err(e) => (Err(e), buf),
+        }
+    }
+
+    fn writev<T: IoVecBuf>(&mut self, buf_vec: T) -> impl Future<Output = BufResult<usize, T>> {
+        std::future::ready(cursor_writev_logic(self, buf_vec))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        std::future::ready(Write::flush(self))
+    }
+
+    #[inline]
+    fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        // Cursor is in-memory, flush is a no-op, so shutdown is also a no-op.
+        std::future::ready(Ok(()))
+    }
+}
+
+impl<T: ?Sized + AsyncWriteRent + Unpin> AsyncWriteRent for Box<T> {
+    #[inline]
+    fn write<B: IoBuf>(&mut self, buf: B) -> impl Future<Output = BufResult<usize, B>> {
+        (**self).write(buf)
+    }
+
+    #[inline]
+    fn writev<B: IoVecBuf>(&mut self, buf_vec: B) -> impl Future<Output = BufResult<usize, B>> {
+        (**self).writev(buf_vec)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        (**self).flush()
+    }
+
+    #[inline]
+    fn shutdown(&mut self) -> impl Future<Output = std::io::Result<()>> {
+        (**self).shutdown()
     }
 }

--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -139,7 +139,7 @@ fn write_vectored_logic<C: std::io::Write + ?Sized, T: IoVecBuf>(
     #[cfg(windows)]
     {
         // SAFETY: IoSlice<'_> is repr(transparent) over WSABUF
-        let bufs = unsafe {
+        bufs = unsafe {
             std::slice::from_raw_parts(
                 buf_vec.read_wsabuf_ptr() as *const std::io::IoSlice<'_>,
                 buf_vec.read_wsabuf_len(),

--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -211,12 +211,8 @@ impl AsyncWriteRent for Vec<u8> {
             // SAFETY: IoVecBuf guarantees valid WSABUF array
             let wsabuf_array_ptr = buf_vec.read_wsabuf_ptr();
             let wsabuf_count = buf_vec.read_wsabuf_len();
-            let wsabuf_slice = unsafe {
-                std::slice::from_raw_parts(
-                    wsabuf_array_ptr as *const windows_sys::Win32::Networking::WinSock::WSABUF,
-                    wsabuf_count,
-                )
-            };
+            let wsabuf_slice =
+                unsafe { std::slice::from_raw_parts(wsabuf_array_ptr, wsabuf_count) };
             total_bytes_to_write = extend_vec_from_platform_bufs(
                 self,
                 wsabuf_slice,

--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -147,10 +147,10 @@ fn write_vectored_logic<C: std::io::Write + ?Sized, T: IoVecBuf>(
         };
     }
     let res = std::io::Write::write_vectored(writer, bufs);
-    return match res {
+    match res {
         Ok(n) => (Ok(n), buf_vec),
         Err(e) => (Err(e), buf_vec),
-    };
+    }
 }
 
 // Helper function to extend a Vec<u8> from platform-specific buffer slices

--- a/monoio/src/macros/pin.rs
+++ b/monoio/src/macros/pin.rs
@@ -11,13 +11,14 @@
 /// The following will **fail to compile**:
 ///
 /// ```compile_fail
+/// use monoio::pin;
 /// async fn my_async_fn() {
 ///     // async logic here
 /// }
 ///
 /// #[monoio::main]
 /// async fn main() {
-///     let mut future = my_async_fn();
+///     let mut future = pin!(my_async_fn());
 ///     (&mut future).await;
 /// }
 /// ```
@@ -54,6 +55,7 @@
 /// The following does not compile as an expression is passed to `pin!`.
 ///
 /// ```compile_fail
+/// use monoio::pin;
 /// async fn my_async_fn() {
 ///     // async logic here
 /// }

--- a/monoio/tests/async_read_rent_mut_slice.rs
+++ b/monoio/tests/async_read_rent_mut_slice.rs
@@ -1,5 +1,4 @@
-use monoio::buf::VecBuf;
-use monoio::io::AsyncReadRent;
+use monoio::{buf::VecBuf, io::AsyncReadRent};
 
 #[monoio::test_all]
 async fn test_async_read_rent_for_mut_slice() {

--- a/monoio/tests/async_read_rent_mut_slice.rs
+++ b/monoio/tests/async_read_rent_mut_slice.rs
@@ -1,0 +1,53 @@
+use monoio::buf::VecBuf;
+use monoio::io::AsyncReadRent;
+
+#[monoio::test_all]
+async fn test_async_read_rent_for_mut_slice() {
+    let mut src: &mut [u8] = &mut *Box::new(*b"hello world");
+    let dst = vec![0u8; 5];
+
+    // Read 5 bytes from src into dst
+    let (res, dst) = src.read(dst).await;
+    assert_eq!(res.unwrap(), 5);
+    assert_eq!(&dst, b"hello");
+
+    // Read the rest
+    let dst2 = vec![0u8; 6];
+    let (res, dst2) = src.read(dst2).await;
+    assert_eq!(res.unwrap(), 6);
+    assert_eq!(&dst2, b" world");
+
+    // Now src should be empty
+    let dst3 = vec![0u8; 1];
+    let (res, _) = src.read(dst3).await;
+    assert_eq!(res.unwrap(), 0);
+}
+
+#[monoio::test_all]
+async fn test_async_read_rent_for_mut_slice_readv() {
+    let mut src: &mut [u8] = &mut *Box::new(*b"hello world");
+    let buf_vec = VecBuf::from(vec![vec![0u8; 5], vec![0u8; 6]]);
+    let (res, buf_vec) = src.readv(buf_vec).await;
+    assert_eq!(res.unwrap(), 11);
+    let raw_vec: Vec<Vec<u8>> = buf_vec.into();
+    assert_eq!(&raw_vec[0], b"hello");
+    assert_eq!(&raw_vec[1], b" world");
+    // Now src should be empty
+    let buf_vec = VecBuf::from(vec![vec![0u8; 1]]);
+    let (res, _) = src.readv(buf_vec).await;
+    assert_eq!(res.unwrap(), 0);
+}
+
+#[monoio::test_all]
+async fn test_mutability_after_read() {
+    let mut backing = *b"hello world";
+    let mut src: &mut [u8] = &mut backing;
+    let dst = vec![0u8; 5];
+    let (_res, _dst) = src.read(dst).await;
+    // Mutate the remaining part of the slice
+    if !src.is_empty() {
+        src[0] = b'X';
+    }
+    // The original buffer should now be b"helloXworld"
+    assert_eq!(&backing, b"helloXworld");
+}

--- a/monoio/tests/async_write_rent_boxed.rs
+++ b/monoio/tests/async_write_rent_boxed.rs
@@ -1,6 +1,9 @@
-use monoio::buf::VecBuf;
-use monoio::io::{AsyncWriteRent, AsyncWriteRentExt, BufWriter};
 use std::io::Cursor;
+
+use monoio::{
+    buf::VecBuf,
+    io::{AsyncWriteRent, AsyncWriteRentExt, BufWriter},
+};
 
 const TEST_DATA: &[u8] = b"Hello, Boxed AsyncWriteRent!";
 const LARGE_TEST_DATA: &[u8] = b"This is a larger test string to ensure proper handling of multiple writes in boxed AsyncWriteRent...";

--- a/monoio/tests/async_write_rent_boxed.rs
+++ b/monoio/tests/async_write_rent_boxed.rs
@@ -1,0 +1,111 @@
+use monoio::buf::VecBuf;
+use monoio::io::{AsyncWriteRent, AsyncWriteRentExt, BufWriter};
+use std::io::Cursor;
+
+const TEST_DATA: &[u8] = b"Hello, Boxed AsyncWriteRent!";
+const LARGE_TEST_DATA: &[u8] = b"This is a larger test string to ensure proper handling of multiple writes in boxed AsyncWriteRent...";
+
+#[monoio::test_all]
+async fn test_boxed_cursor_vec() {
+    let cursor = Cursor::new(Vec::new());
+    let mut writer = Box::new(cursor);
+
+    // Test single write
+    let (res, _) = writer.write(TEST_DATA).await;
+    assert_eq!(res.unwrap(), TEST_DATA.len());
+    assert_eq!(&writer.get_ref()[..TEST_DATA.len()], TEST_DATA);
+
+    // Test write_all
+    let (res, _) = writer.write_all(LARGE_TEST_DATA).await;
+    assert_eq!(res.unwrap(), LARGE_TEST_DATA.len());
+    assert_eq!(&writer.get_ref()[TEST_DATA.len()..], LARGE_TEST_DATA);
+
+    // Test flush and shutdown (should be no-ops for Cursor)
+    assert!(writer.flush().await.is_ok());
+    assert!(writer.shutdown().await.is_ok());
+}
+
+#[monoio::test_all]
+async fn test_boxed_cursor_vec_writev() {
+    let cursor = Cursor::new(Vec::new());
+    let mut writer = Box::new(cursor);
+
+    let buf_vec = VecBuf::from(vec![b"foo".to_vec(), b"bar".to_vec()]);
+    let (res, _) = writer.writev(buf_vec).await;
+    assert_eq!(res.unwrap(), 6);
+    assert_eq!(&writer.get_ref()[..6], b"foobar");
+}
+
+#[monoio::test_all]
+async fn test_boxed_bufwriter_cursor_vec() {
+    let buf_writer = BufWriter::new(Cursor::new(Vec::new()));
+    let mut writer = Box::new(buf_writer);
+
+    let (res, _) = writer.write(TEST_DATA).await;
+    assert_eq!(res.unwrap(), TEST_DATA.len());
+    assert!(writer.flush().await.is_ok());
+}
+
+#[monoio::test_all]
+async fn test_boxed_cursor_box_slice() {
+    let data = vec![0u8; 16].into_boxed_slice();
+    let mut writer = Box::new(Cursor::new(data));
+
+    // Write less than capacity
+    let (res, _) = writer.write(TEST_DATA).await;
+    let expected = std::cmp::min(TEST_DATA.len(), 16);
+    assert_eq!(res.unwrap(), expected);
+    assert_eq!(&writer.get_ref()[..expected], &TEST_DATA[..expected]);
+
+    // Write when full
+    writer.set_position(16);
+    let (res, _) = writer.write(TEST_DATA).await;
+    assert_eq!(res.unwrap(), 0);
+}
+
+#[monoio::test_all]
+async fn test_boxed_cursor_vec_zero_length_write() {
+    let mut writer = Box::new(Cursor::new(Vec::new()));
+    let (res, _) = writer.write(&[]).await;
+    assert_eq!(res.unwrap(), 0);
+}
+
+// Error handling: mock a type that returns error on write
+struct ErrorWriter;
+
+impl AsyncWriteRent for ErrorWriter {
+    fn write<T: monoio::buf::IoBuf>(
+        &mut self,
+        _buf: T,
+    ) -> impl std::future::Future<Output = monoio::BufResult<usize, T>> {
+        std::future::ready((
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "fail")),
+            _buf,
+        ))
+    }
+    fn writev<T: monoio::buf::IoVecBuf>(
+        &mut self,
+        _buf_vec: T,
+    ) -> impl std::future::Future<Output = monoio::BufResult<usize, T>> {
+        std::future::ready((
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "fail")),
+            _buf_vec,
+        ))
+    }
+    fn flush(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> {
+        std::future::ready(Ok(()))
+    }
+    fn shutdown(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> {
+        std::future::ready(Ok(()))
+    }
+}
+
+#[monoio::test_all]
+async fn test_boxed_error_writer() {
+    let mut writer = Box::new(ErrorWriter);
+    let (res, _) = writer.write(TEST_DATA).await;
+    assert!(res.is_err());
+    let buf_vec = VecBuf::from(vec![b"foo".to_vec()]);
+    let (res, _) = writer.writev(buf_vec).await;
+    assert!(res.is_err());
+}

--- a/monoio/tests/async_write_rent_cursor.rs
+++ b/monoio/tests/async_write_rent_cursor.rs
@@ -1,8 +1,9 @@
+use std::io::Cursor;
+
 use monoio::{
     buf::VecBuf,
     io::{AsyncWriteRent, AsyncWriteRentExt},
 };
-use std::io::Cursor;
 
 const TEST_DATA: &[u8] = b"Hello, Monoio!";
 const LARGE_TEST_DATA: &[u8] =

--- a/monoio/tests/async_write_rent_cursor.rs
+++ b/monoio/tests/async_write_rent_cursor.rs
@@ -1,0 +1,194 @@
+use monoio::{
+    buf::VecBuf,
+    io::{AsyncWriteRent, AsyncWriteRentExt},
+};
+use std::io::Cursor;
+
+const TEST_DATA: &[u8] = b"Hello, Monoio!";
+const LARGE_TEST_DATA: &[u8] =
+    b"This is a larger test string to ensure proper handling of multiple writes...";
+
+#[monoio::test_all]
+async fn test_cursor_vec() {
+    let vec = Vec::new();
+    let mut cursor = Cursor::new(vec);
+
+    // Test single write
+    let (res, _) = cursor.write(TEST_DATA).await;
+    assert_eq!(res.unwrap(), TEST_DATA.len());
+    assert_eq!(&cursor.get_ref()[..TEST_DATA.len()], TEST_DATA);
+
+    // Test write_all
+    let (res, _) = cursor.write_all(LARGE_TEST_DATA).await;
+    assert_eq!(res.unwrap(), LARGE_TEST_DATA.len());
+    assert_eq!(&cursor.get_ref()[TEST_DATA.len()..], LARGE_TEST_DATA);
+
+    // Test flush and shutdown (should be no-ops for Cursor)
+    assert!(cursor.flush().await.is_ok());
+    assert!(cursor.shutdown().await.is_ok());
+}
+
+#[monoio::test_all]
+async fn test_cursor_mut_vec() {
+    let mut vec = Vec::new();
+    let mut cursor = Cursor::new(&mut vec);
+
+    // Test single write
+    let (res, _) = cursor.write(TEST_DATA).await;
+    assert_eq!(res.unwrap(), TEST_DATA.len());
+
+    // Get a reference to vec through cursor to avoid borrow checker issues
+    {
+        let written_data = cursor.get_ref();
+        assert_eq!(&written_data[..TEST_DATA.len()], TEST_DATA);
+    }
+
+    // Test write_all
+    let (res, _) = cursor.write_all(LARGE_TEST_DATA).await;
+    assert_eq!(res.unwrap(), LARGE_TEST_DATA.len());
+
+    // Get a reference to vec through cursor to avoid borrow checker issues
+    {
+        let written_data = cursor.get_ref();
+        assert_eq!(&written_data[TEST_DATA.len()..], LARGE_TEST_DATA);
+    }
+}
+
+#[monoio::test_all]
+async fn test_cursor_mut_slice() {
+    let mut data = vec![0u8; 32];
+    {
+        let mut cursor = Cursor::new(&mut data[..]);
+
+        // Test write (should only write up to slice capacity)
+        let (res, _) = cursor.write(TEST_DATA).await;
+        assert_eq!(res.unwrap(), TEST_DATA.len());
+
+        // Get a reference through cursor
+        {
+            let written_data = cursor.get_ref();
+            assert_eq!(&written_data[..TEST_DATA.len()], TEST_DATA);
+        }
+
+        // Test write beyond capacity (should return number of bytes that fit)
+        let pos = cursor.position() as usize;
+        let remaining = cursor.get_ref().len() - pos;
+        let (res, _) = cursor.write(LARGE_TEST_DATA).await;
+        let expected_write = std::cmp::min(LARGE_TEST_DATA.len(), remaining);
+        assert_eq!(res.unwrap(), expected_write);
+    }
+}
+
+#[monoio::test_all]
+async fn test_cursor_box_slice() {
+    let data = vec![0u8; 32].into_boxed_slice();
+    let mut cursor = Cursor::new(data);
+
+    // Test write
+    let (res, _) = cursor.write(TEST_DATA).await;
+    assert_eq!(res.unwrap(), TEST_DATA.len());
+    assert_eq!(&cursor.get_ref()[..TEST_DATA.len()], TEST_DATA);
+
+    // Test write beyond capacity
+    let remaining = cursor.get_ref().len() - cursor.position() as usize;
+    let expected_write = std::cmp::min(LARGE_TEST_DATA.len(), remaining);
+    let (res, _) = cursor.write(LARGE_TEST_DATA).await;
+    assert_eq!(res.unwrap(), expected_write);
+}
+
+// Test vectored writes using VecBuf
+#[monoio::test_all]
+async fn test_cursor_vectored_write() {
+    let vec = Vec::new();
+    let mut cursor = Cursor::new(vec);
+
+    // Create VecBuf with multiple buffers
+    let buf_vec = VecBuf::from(vec![TEST_DATA[..5].to_vec(), TEST_DATA[5..].to_vec()]);
+
+    // Test vectored write
+    let (res, buf_vec) = cursor.writev(buf_vec).await;
+    assert_eq!(res.unwrap(), TEST_DATA.len());
+    assert_eq!(cursor.get_ref(), TEST_DATA);
+
+    // Convert back to Vec<Vec<u8>> and verify the buffers are unchanged
+    let raw_vec: Vec<Vec<u8>> = buf_vec.into();
+    assert_eq!(&raw_vec[0], &TEST_DATA[..5]);
+    assert_eq!(&raw_vec[1], &TEST_DATA[5..]);
+
+    // Test vectored write with multiple chunks
+    let buf_vec = VecBuf::from(vec![
+        LARGE_TEST_DATA[..10].to_vec(),
+        LARGE_TEST_DATA[10..20].to_vec(),
+        LARGE_TEST_DATA[20..].to_vec(),
+    ]);
+
+    let (res, buf_vec) = cursor.writev(buf_vec).await;
+    assert_eq!(res.unwrap(), LARGE_TEST_DATA.len());
+    assert_eq!(&cursor.get_ref()[TEST_DATA.len()..], LARGE_TEST_DATA);
+
+    // Verify the original buffers are unchanged
+    let raw_vec: Vec<Vec<u8>> = buf_vec.into();
+    assert_eq!(&raw_vec[0], &LARGE_TEST_DATA[..10]);
+    assert_eq!(&raw_vec[1], &LARGE_TEST_DATA[10..20]);
+    assert_eq!(&raw_vec[2], &LARGE_TEST_DATA[20..]);
+}
+
+// Test vectored writes with fixed-size buffers
+#[monoio::test_all]
+async fn test_cursor_vectored_write_fixed_size() {
+    let mut data = vec![0u8; 32];
+    {
+        let mut cursor = Cursor::new(&mut data[..]);
+
+        // Create VecBuf that would exceed the buffer capacity
+        let buf_vec = VecBuf::from(vec![
+            vec![1; 16],
+            vec![2; 16],
+            vec![3; 16], // This should be partially written or not written at all
+        ]);
+
+        let total_size = 48; // Total size of all buffers
+        let capacity = cursor.get_ref().len();
+        let (res, buf_vec) = cursor.writev(buf_vec).await;
+        let expected_write = std::cmp::min(total_size, capacity);
+        assert_eq!(res.unwrap(), expected_write);
+
+        // Get a reference through cursor to verify the data
+        {
+            let written_data = cursor.get_ref();
+            assert_eq!(&written_data[..16], &[1; 16]);
+            assert_eq!(&written_data[16..32], &[2; 16]);
+        }
+
+        // Verify the original buffers are unchanged
+        let raw_vec: Vec<Vec<u8>> = buf_vec.into();
+        assert_eq!(&raw_vec[0], &[1; 16]);
+        assert_eq!(&raw_vec[1], &[2; 16]);
+        assert_eq!(&raw_vec[2], &[3; 16]);
+    }
+}
+
+// Test error conditions
+#[monoio::test_all]
+async fn test_cursor_error_conditions() {
+    let mut data = vec![0u8; 8];
+    {
+        let mut cursor = Cursor::new(&mut data[..]);
+
+        // First write should succeed
+        let (res, _) = cursor.write(&[1, 2, 3, 4]).await;
+        assert_eq!(res.unwrap(), 4);
+
+        // Move cursor to end
+        cursor.set_position(8);
+
+        // Write at end should return 0 bytes written
+        let (res, _) = cursor.write(&[5, 6, 7, 8]).await;
+        assert_eq!(res.unwrap(), 0);
+
+        // Test vectored write at end
+        let buf_vec = VecBuf::from(vec![vec![5; 4], vec![6; 4]]);
+        let (res, _) = cursor.writev(buf_vec).await;
+        assert_eq!(res.unwrap(), 0);
+    }
+}


### PR DESCRIPTION
Addresses [#310](https://github.com/bytedance/monoio/issues/310).

**Changes based on the commit:**

*   **`AsyncReadRent`:**
    *   Implemented for `&mut [u8]`.
*   **`AsyncWriteRent`:**
    *   Refactored for `Vec<u8>`.
    *   Implemented for `Cursor<&mut Vec<u8>>`.
    *   Implemented for `Cursor<&mut [u8]>`.
    *   Implemented for `Cursor<Box<[u8]>>`.
    *   Implemented for `Cursor<Vec<u8>>`.
    *   Implemented for `Box<T: ?Sized + AsyncWriteRent + Unpin>`.
*   **Helpers:** Added helper functions (`iovecs_to_slices`, `wsabufs_to_slices`, `cursor_writev_logic`) to support `writev` implementations, particularly for `Cursor`.
*   **Tests:** Added/verified test coverage for the new implementations:
    *   `tests/async_read_rent_mut_slice.rs`: Covers `AsyncReadRent for &mut [u8]`.
    *   `tests/async_write_rent_cursor.rs`: Covers `AsyncWriteRent for Cursor<T>` types.
    *   `tests/async_write_rent_boxed.rs`: Covers `AsyncWriteRent for Box<T>`.