### PR TITLE
feat: introduce `zero_copy_from_pipe()` and `zero_copy_to_pipe()`

### DIFF
--- a/monoio/src/io/mod.rs
+++ b/monoio/src/io/mod.rs
@@ -30,12 +30,12 @@ mod util;
 #[cfg(feature = "poll-io")]
 pub use tokio::io as poll_io;
 pub(crate) use util::operation_canceled;
-#[cfg(all(target_os = "linux", feature = "splice"))]
-pub use util::zero_copy;
 pub use util::{
     copy, BufReader, BufWriter, CancelHandle, Canceller, OwnedReadHalf, OwnedWriteHalf,
     PrefixedReadIo, Split, Splitable,
 };
+#[cfg(all(target_os = "linux", feature = "splice"))]
+pub use util::{zero_copy, zero_copy_from_pipe, zero_copy_to_pipe};
 #[cfg(feature = "poll-io")]
 /// Convert a completion-based io to a poll-based io.
 pub trait IntoPollIo: Sized {

--- a/monoio/src/io/util/mod.rs
+++ b/monoio/src/io/util/mod.rs
@@ -13,6 +13,6 @@ pub(crate) use cancel::operation_canceled;
 pub use cancel::{CancelHandle, Canceller};
 pub use copy::copy;
 #[cfg(all(target_os = "linux", feature = "splice"))]
-pub use copy::zero_copy;
+pub use copy::{zero_copy, zero_copy_from_pipe, zero_copy_to_pipe};
 pub use prefixed_io::PrefixedReadIo;
 pub use split::{OwnedReadHalf, OwnedWriteHalf, Split, Splitable};


### PR DESCRIPTION
#351 brought my monoio version of `yes | netcat -l -p 1234` to 80% of the expected performance, but that's not where a high performance Rust library can stop.

Looking at the code, I realized that `zero_copy()` always creates a new `Pipe`. If either the reader or the writer is already a `Pipe`, this is not necessary.

This PR adds two functions for those cases. Together with #351, monoio now matches `yes | netcat ...`.
Without #351, this almost doubles the performance (~160MiB/s -> ~310MiB/s) on my box, but the use case really needs the larger buffer.