### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           OS: ${{ matrix.os }}
           PROJECT_DIR: ${{ github.workspace }}
           NO_RUN: ${{ matrix.no_run }}
+          RUSTFLAGS: ${{ matrix.io_uring_skip_arch_check && '--cfg=io_uring_skip_arch_check' || '' }}
         run: sh .github/workflows/ci.sh
 
     strategy:
@@ -88,10 +89,12 @@ jobs:
             os: ubuntu-latest
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-latest
+            io_uring_skip_arch_check: true
           - target: riscv64gc-unknown-linux-gnu 
             os: ubuntu-latest
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
+            io_uring_skip_arch_check: true
           - target: loongarch64-unknown-linux-gnu
             os: ubuntu-latest
 #          - target: mips64-unknown-linux-muslabi64

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1", default-features = false, features = ["io-util"] }
 tower-service = "0.3"
 
 futures = "0.3"
-local-sync = "0.0.5"
+local-sync = "0.1"
 pin-project-lite = "0.2"
 
 [[example]]

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -15,7 +15,6 @@ version = "0.2.4"
 monoio-macros = { version = "0.1.0", path = "../monoio-macros", optional = true }
 
 auto-const-array = "0.2"
-fxhash = "0.2"
 libc = "0.2"
 pin-project-lite = "0.2"
 socket2 = { version = "0.6", features = ["all"] }
@@ -36,6 +35,7 @@ tracing = { version = "0.1", default-features = false, features = [
 ctrlc = { version = "3", optional = true }
 lazy_static = { version = "1", optional = true }
 once_cell = { version = "1.19.0", optional = true }
+rustc-hash = "2.1.1"
 
 # windows dependencies(will be added when windows support finished)
 [target.'cfg(windows)'.dependencies]

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -18,12 +18,12 @@ auto-const-array = "0.2"
 fxhash = "0.2"
 libc = "0.2"
 pin-project-lite = "0.2"
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 memchr = "2.7"
 
 bytes = { version = "1", optional = true }
 flume = { version = "0.11", optional = true }
-mio = { version = "0.8", features = [
+mio = { version = "1.0", features = [
     "net",
     "os-poll",
     "os-ext",
@@ -49,14 +49,14 @@ windows-sys = { version = "0.48.0", features = [
 
 # unix dependencies
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["sched", "ucontext", "process"], optional = true }
+nix = { version = "0.30", features = ["sched", "ucontext", "process"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = { version = "0.6", optional = true }
+io-uring = { version = "0.7", optional = true }
 
 [dev-dependencies]
 futures = "0.3"
-local-sync = "0.0.5"
+local-sync = "0.1"
 tempfile = "3.2"
 
 [features]

--- a/monoio/src/driver/thread.rs
+++ b/monoio/src/driver/thread.rs
@@ -3,9 +3,9 @@ use std::sync::LazyLock;
 use std::{sync::Mutex, task::Waker};
 
 use flume::Sender;
-use fxhash::FxHashMap;
 #[cfg(not(feature = "unstable"))]
 use once_cell::sync::Lazy as LazyLock;
+use rustc_hash::FxHashMap;
 
 use crate::driver::UnparkHandle;
 

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -603,11 +603,11 @@ impl StreamMeta {
     }
 
     fn no_delay(&self) -> io::Result<bool> {
-        self.socket.as_ref().unwrap().nodelay()
+        self.socket.as_ref().unwrap().tcp_nodelay()
     }
 
     fn set_no_delay(&self, no_delay: bool) -> io::Result<()> {
-        self.socket.as_ref().unwrap().set_nodelay(no_delay)
+        self.socket.as_ref().unwrap().set_tcp_nodelay(no_delay)
     }
 
     #[allow(unused_variables)]

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -21,8 +21,8 @@ use crate::{
 thread_local! {
     pub(crate) static DEFAULT_CTX: Context = Context {
         thread_id: crate::utils::thread_id::DEFAULT_THREAD_ID,
-        unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-        waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+        unpark_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+        waker_sender_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
         tasks: Default::default(),
         time_handle: None,
         blocking_handle: crate::blocking::BlockingHandle::Empty(crate::blocking::BlockingStrategy::Panic),
@@ -41,12 +41,12 @@ pub(crate) struct Context {
     /// Thread unpark handles
     #[cfg(feature = "sync")]
     pub(crate) unpark_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, crate::driver::UnparkHandle>>,
+        std::cell::RefCell<rustc_hash::FxHashMap<usize, crate::driver::UnparkHandle>>,
 
     /// Waker sender cache
     #[cfg(feature = "sync")]
     pub(crate) waker_sender_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
+        std::cell::RefCell<rustc_hash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
 
     /// Time Handle
     pub(crate) time_handle: Option<TimeHandle>,
@@ -63,8 +63,8 @@ impl Context {
 
         Self {
             thread_id,
-            unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-            waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+            unpark_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+            waker_sender_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
             tasks: TaskQueue::default(),
             time_handle: None,
             blocking_handle,


### PR DESCRIPTION
This change updates all dependencies to their latest released versions.

Dependencies updated:

- `io-uring`
- `local-sync`
- `mio`
- `nix`
- `socket2`

This is mainly to reduce duplicates of these in the build graph of downstream crates using newer versions.

EDIT: I removed the updates to `windows-sys` because it requires deeper refactoring to the internals.