### PR TITLE
Performance Improvements and Refactoring: Replace flume with crossbeam SegQueue

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -21,8 +21,8 @@ pin-project-lite = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
 memchr = "2.7"
 
+crossbeam-queue = { version = "0.3", optional = true }
 bytes = { version = "1", optional = true }
-flume = { version = "0.11", optional = true }
 mio = { version = "0.8", features = [
     "net",
     "os-poll",
@@ -49,7 +49,11 @@ windows-sys = { version = "0.48.0", features = [
 
 # unix dependencies
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["sched", "ucontext", "process"], optional = true }
+nix = { version = "0.29", features = [
+    "sched",
+    "ucontext",
+    "process",
+], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6", optional = true }
@@ -81,7 +85,7 @@ symlinkat = []
 # enable `async main` macros support
 macros = ["monoio-macros"]
 # allow waker to be sent across threads
-sync = ["flume", "threadpool", "once_cell"]
+sync = ["crossbeam-queue", "threadpool", "once_cell"]
 # enable bind cpu set
 utils = ["nix"]
 # enable debug if you want to know what runtime does

--- a/monoio/src/driver/thread.rs
+++ b/monoio/src/driver/thread.rs
@@ -1,8 +1,11 @@
 #[cfg(feature = "unstable")]
 use std::sync::LazyLock;
-use std::{sync::Mutex, task::Waker};
+use std::{
+    sync::{Arc, Mutex},
+    task::Waker,
+};
 
-use flume::Sender;
+use crossbeam_queue::SegQueue;
 use fxhash::FxHashMap;
 #[cfg(not(feature = "unstable"))]
 use once_cell::sync::Lazy as LazyLock;
@@ -13,7 +16,7 @@ static UNPARK: LazyLock<Mutex<FxHashMap<usize, UnparkHandle>>> =
     LazyLock::new(|| Mutex::new(FxHashMap::default()));
 
 // Global waker sender map
-static WAKER_SENDER: LazyLock<Mutex<FxHashMap<usize, Sender<Waker>>>> =
+static WAKER_QUEUE: LazyLock<Mutex<FxHashMap<usize, Arc<SegQueue<Waker>>>>> =
     LazyLock::new(|| Mutex::new(FxHashMap::default()));
 
 macro_rules! lock {
@@ -35,14 +38,14 @@ pub(crate) fn get_unpark_handle(id: usize) -> Option<UnparkHandle> {
     lock!(UNPARK).get(&id).cloned()
 }
 
-pub(crate) fn register_waker_sender(id: usize, sender: Sender<Waker>) {
-    lock!(WAKER_SENDER).insert(id, sender);
+pub(crate) fn register_waker_queue(id: usize, sender: Arc<SegQueue<Waker>>) {
+    lock!(WAKER_QUEUE).insert(id, sender);
 }
 
-pub(crate) fn unregister_waker_sender(id: usize) {
-    lock!(WAKER_SENDER).remove(&id);
+pub(crate) fn unregister_waker_queue(id: usize) {
+    lock!(WAKER_QUEUE).remove(&id);
 }
 
-pub(crate) fn get_waker_sender(id: usize) -> Option<Sender<Waker>> {
-    lock!(WAKER_SENDER).get(&id).cloned()
+pub(crate) fn get_waker_queue(id: usize) -> Option<Arc<SegQueue<Waker>>> {
+    lock!(WAKER_QUEUE).get(&id).cloned()
 }

--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -116,8 +116,7 @@ impl IoUringDriver {
 
         Ok(IoUringDriver {
             inner,
-            timespec: UnsafeCell::new(Timespec::new()),
-            _pinned: std::marker::PhantomPinned,
+            timespec: Box::leak(Box::new(Timespec::new())) as *mut Timespec,
         })
     }
 

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -1,4 +1,9 @@
 use std::future::Future;
+#[cfg(feature = "sync")]
+use std::sync::Arc;
+
+#[cfg(feature = "sync")]
+use crossbeam_queue::SegQueue;
 
 #[cfg(any(all(target_os = "linux", feature = "iouring"), feature = "legacy"))]
 use crate::time::TimeDriver;
@@ -22,7 +27,7 @@ thread_local! {
     pub(crate) static DEFAULT_CTX: Context = Context {
         thread_id: crate::utils::thread_id::DEFAULT_THREAD_ID,
         unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-        waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+        waker_queue_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
         tasks: Default::default(),
         time_handle: None,
         blocking_handle: crate::blocking::BlockingHandle::Empty(crate::blocking::BlockingStrategy::Panic),
@@ -45,8 +50,8 @@ pub(crate) struct Context {
 
     /// Waker sender cache
     #[cfg(feature = "sync")]
-    pub(crate) waker_sender_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
+    pub(crate) waker_queue_cache:
+        std::cell::RefCell<fxhash::FxHashMap<usize, Arc<SegQueue<std::task::Waker>>>>,
 
     /// Time Handle
     pub(crate) time_handle: Option<TimeHandle>,
@@ -64,7 +69,7 @@ impl Context {
         Self {
             thread_id,
             unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-            waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+            waker_queue_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
             tasks: TaskQueue::default(),
             time_handle: None,
             blocking_handle,
@@ -102,16 +107,16 @@ impl Context {
     #[allow(unused)]
     #[cfg(feature = "sync")]
     pub(crate) fn send_waker(&self, id: usize, w: std::task::Waker) {
-        use crate::driver::thread::get_waker_sender;
-        if let Some(sender) = self.waker_sender_cache.borrow().get(&id) {
-            let _ = sender.send(w);
+        use crate::driver::thread::get_waker_queue;
+        if let Some(sender) = self.waker_queue_cache.borrow().get(&id) {
+            let _ = sender.push(w);
             return;
         }
 
-        if let Some(s) = get_waker_sender(id) {
+        if let Some(s) = get_waker_queue(id) {
             // Write back to local cache
-            let _ = s.send(w);
-            self.waker_sender_cache.borrow_mut().insert(id, s);
+            let _ = s.push(w);
+            self.waker_queue_cache.borrow_mut().insert(id, s);
         }
     }
 }

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -1,7 +1,6 @@
 use std::{
     io::Write,
     net::{IpAddr, SocketAddr},
-    sync::LazyLock,
     thread::sleep,
     time::Duration,
 };


### PR DESCRIPTION
Hi,
This PR improves performance in various parts of the code and includes some refactoring.

Main changes are:
1. ~In the iouring driver, I removed two heap allocations, which simplifies the implementation and should slightly improve performance.~ (will send it in separate PR with correct Pin usage)
2. I removed flume. As the creator of the kanal, I respect the flume project as a safe channel implementation, but in this library, the channel structure is unnecessary and not required since it is effectively being used as a queue. Queues always outperform channels because they are simpler structures with fewer features. Using the lock-free crossbeam unbounded SegQueue should improve performance under high contention, as the use case does not require blocking recv, which is a channel feature.
3. Slight refactoring and improvements in other parts of project.