### PR TITLE
feat: recv/recvmsg multishot support for io_uring driver

### DIFF
--- a/monoio/src/buf/mod.rs
+++ b/monoio/src/buf/mod.rs
@@ -24,6 +24,14 @@ pub(crate) use vec_wrapper::{read_vec_meta, write_vec_meta, IoVecMeta};
 mod msg;
 pub use msg::{MsgBuf, MsgBufMut, MsgMeta};
 
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+mod ring_buf;
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub use ring_buf::{
+    AnyRecvMsgParser, Ipv4RecvMsgParser, Ipv6RecvMsgParser, RawBuffer, RecvMsgParser,
+    RecvMsgRingBuf, RingBuf, UserRecvMsgRingBuf, UserRingBuf, UserRingBufBuilder,
+};
+
 pub(crate) fn deref(buf: &impl IoBuf) -> &[u8] {
     // Safety: the `IoBuf` trait is marked as unsafe and is expected to be
     // implemented correctly.

--- a/monoio/src/buf/ring_buf.rs
+++ b/monoio/src/buf/ring_buf.rs
@@ -1,0 +1,605 @@
+//! Buffer ring support for io_uring provided buffers.
+
+use std::{
+    cell::UnsafeCell,
+    io,
+    marker::PhantomData,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+    sync::atomic::{AtomicU16, Ordering},
+};
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub(super) use io_uring::types::BufRingEntry;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Trait for buffer ring implementations.
+///
+/// This trait is sealed and cannot be implemented outside of this crate.
+pub trait RingBuf: sealed::Sealed {
+    /// Buffer type returned by this ring.
+    type Buffer<'a>:
+    where
+        Self: 'a;
+
+    /// Buffer group ID.
+    fn bgid(&self) -> u16;
+    /// Size of each buffer.
+    fn buffer_size(&self) -> usize;
+    /// Number of buffers.
+    fn buffer_count(&self) -> usize;
+
+    /// # Safety
+    /// buf_id and len must come from a valid io_uring completion.
+    unsafe fn get_buf(&self, buf_id: u16, len: usize) -> Self::Buffer<'_>;
+}
+
+/// Buffer ring with recvmsg address parsing support.
+pub trait RecvMsgRingBuf: RingBuf {
+    /// Parser type for address extraction.
+    type Parser: RecvMsgParser + Unpin + 'static;
+
+    /// Parse a recvmsg completion and return the address and payload buffer.
+    ///
+    /// # Safety
+    /// buf_id and len must come from a valid io_uring recvmsg completion.
+    unsafe fn parse_recvmsg(
+        &self,
+        buf_id: u16,
+        len: usize,
+        msghdr: &libc::msghdr,
+    ) -> io::Result<(<Self::Parser as RecvMsgParser>::Address, Self::Buffer<'_>)>;
+}
+
+const RECVMSG_OUT_HEADER_SIZE: usize = std::mem::size_of::<[u32; 4]>();
+
+/// Trait for parsing recvmsg address headers.
+///
+/// This trait is sealed and cannot be implemented outside of this crate.
+pub trait RecvMsgParser: sealed::Sealed {
+    /// Parsed address type.
+    type Address;
+    /// Size of sockaddr structure.
+    const NAME_LEN: libc::socklen_t;
+
+    /// Parse address from raw data.
+    fn parse_address(name_data: &[u8]) -> io::Result<Self::Address>;
+
+    /// Minimum buffer size for headers.
+    #[inline]
+    fn min_buffer_size() -> usize {
+        RECVMSG_OUT_HEADER_SIZE + Self::NAME_LEN as usize
+    }
+}
+
+/// IPv4 address parser.
+pub struct Ipv4RecvMsgParser;
+
+impl sealed::Sealed for Ipv4RecvMsgParser {}
+
+impl RecvMsgParser for Ipv4RecvMsgParser {
+    type Address = SocketAddrV4;
+
+    const NAME_LEN: libc::socklen_t = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+
+    fn parse_address(name_data: &[u8]) -> io::Result<Self::Address> {
+        assert!(name_data.len() >= Self::NAME_LEN as usize);
+        let sockaddr: &libc::sockaddr_in =
+            unsafe { &*(name_data.as_ptr() as *const libc::sockaddr_in) };
+        let ip = Ipv4Addr::from(sockaddr.sin_addr.s_addr.to_ne_bytes());
+        let port = u16::from_be(sockaddr.sin_port);
+        Ok(SocketAddrV4::new(ip, port))
+    }
+}
+
+/// IPv6 address parser.
+pub struct Ipv6RecvMsgParser;
+
+impl sealed::Sealed for Ipv6RecvMsgParser {}
+
+impl RecvMsgParser for Ipv6RecvMsgParser {
+    type Address = SocketAddrV6;
+
+    const NAME_LEN: libc::socklen_t = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
+
+    fn parse_address(name_data: &[u8]) -> io::Result<Self::Address> {
+        assert!(name_data.len() >= Self::NAME_LEN as usize);
+        let sockaddr: &libc::sockaddr_in6 =
+            unsafe { &*(name_data.as_ptr() as *const libc::sockaddr_in6) };
+        let ip = Ipv6Addr::from(sockaddr.sin6_addr.s6_addr);
+        let port = u16::from_be(sockaddr.sin6_port);
+        Ok(SocketAddrV6::new(
+            ip,
+            port,
+            sockaddr.sin6_flowinfo,
+            sockaddr.sin6_scope_id,
+        ))
+    }
+}
+
+/// Parser for any address family.
+pub struct AnyRecvMsgParser;
+
+impl sealed::Sealed for AnyRecvMsgParser {}
+
+impl RecvMsgParser for AnyRecvMsgParser {
+    type Address = SocketAddr;
+
+    const NAME_LEN: libc::socklen_t =
+        std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+
+    fn parse_address(name_data: &[u8]) -> io::Result<Self::Address> {
+        if name_data.len() < 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "address data too short",
+            ));
+        }
+
+        let family = u16::from_ne_bytes([name_data[0], name_data[1]]);
+
+        match family as i32 {
+            libc::AF_INET => Ipv4RecvMsgParser::parse_address(name_data).map(SocketAddr::V4),
+            libc::AF_INET6 => Ipv6RecvMsgParser::parse_address(name_data).map(SocketAddr::V6),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported address family: {}", family),
+            )),
+        }
+    }
+}
+
+/// Builder for [`UserRingBuf`].
+pub struct UserRingBufBuilder {
+    buffer_count: u16,
+    buffer_size: usize,
+    group_id: u16,
+}
+
+impl Default for UserRingBufBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UserRingBufBuilder {
+    /// Create new builder with defaults (16 buffers, 1500 bytes, group 0).
+    pub fn new() -> Self {
+        Self {
+            buffer_count: 16,
+            buffer_size: 1500,
+            group_id: 0,
+        }
+    }
+
+    /// Set buffer count.
+    pub fn buffer_count(mut self, count: u16) -> Self {
+        self.buffer_count = count;
+        self
+    }
+
+    /// Set buffer size.
+    pub fn buffer_size(mut self, size: usize) -> Self {
+        self.buffer_size = size;
+        self
+    }
+
+    /// Set buffer group ID.
+    pub fn group_id(mut self, id: u16) -> Self {
+        self.group_id = id;
+        self
+    }
+
+    /// Build and register the buffer ring.
+    pub fn build(self) -> io::Result<UserRingBuf> {
+        let mut ring = UserRingBuf::new(self.buffer_count, self.buffer_size as u32, self.group_id)?;
+        ring.register()?;
+        Ok(ring)
+    }
+}
+
+/// io_uring provided buffer ring.
+///
+/// The ring entry array is allocated via `mmap` with `MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE`
+/// to ensure the memory is page-aligned.
+///
+/// Automatically unregisters from io_uring and unmaps memory on drop.
+pub struct UserRingBuf {
+    data: UnsafeCell<Box<[u8]>>,
+    buf_count: u16,
+    buf_ring_ptr: Option<NonNull<BufRingEntry>>,
+    ring_entries: u16,
+    buf_len: usize,
+    shared_tail: NonNull<AtomicU16>,
+    buf_group_id: u16,
+    ring_mmap_size: usize,
+    registered: bool,
+}
+
+impl UserRingBuf {
+    fn new(buf_count: u16, buf_size: u32, group_id: u16) -> io::Result<Self> {
+        if buf_count == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "buffer count must be greater than 0",
+            ));
+        }
+        if buf_size == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "buffer size must be greater than 0",
+            ));
+        }
+        if (buf_count & (buf_count - 1)) != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "buffer count must be a power of two",
+            ));
+        }
+        let ring_entries = buf_count;
+        let entry_size = std::mem::size_of::<BufRingEntry>();
+        let ring_mmap_size = entry_size * ring_entries as usize;
+
+        let ring_mem = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                ring_mmap_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_POPULATE,
+                -1,
+                0,
+            )
+        };
+
+        if ring_mem == libc::MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+
+        let buf_ring_ptr = NonNull::new(ring_mem as *mut BufRingEntry).expect("mmap returned null");
+
+        let buf_len = buf_size as usize;
+        let mut data = vec![0u8; buf_count as usize * buf_len].into_boxed_slice();
+
+        for bid in 0..buf_count {
+            let ring_idx = bid & (ring_entries - 1);
+            let entry = unsafe { &mut *buf_ring_ptr.as_ptr().add(ring_idx as usize) };
+            let buf_ptr = data.as_mut_ptr().wrapping_add(bid as usize * buf_len);
+            entry.set_addr(buf_ptr as u64);
+            entry.set_len(buf_size);
+            entry.set_bid(bid);
+        }
+
+        let data = UnsafeCell::new(data);
+
+        let shared_tail = unsafe {
+            NonNull::new_unchecked(BufRingEntry::tail(buf_ring_ptr.as_ptr()) as *mut AtomicU16)
+        };
+
+        unsafe {
+            shared_tail.as_ref().store(buf_count, Ordering::Release);
+        }
+
+        Ok(Self {
+            data,
+            buf_count,
+            buf_ring_ptr: Some(buf_ring_ptr),
+            ring_entries,
+            buf_len,
+            shared_tail,
+            buf_group_id: group_id,
+            ring_mmap_size,
+            registered: false,
+        })
+    }
+
+    fn register(&mut self) -> io::Result<()> {
+        if self.registered {
+            return Ok(());
+        }
+
+        let ptr = self.buf_ring_ptr.expect("UserRingBuf already unmapped");
+        crate::driver::CURRENT.with(|inner| {
+            inner.register_buf_ring(ptr.as_ptr() as u64, self.ring_entries, self.buf_group_id)
+        })?;
+
+        self.registered = true;
+        Ok(())
+    }
+
+    /// Unregister from io_uring. Does nothing if not registered.
+    pub fn unregister(&mut self) -> io::Result<()> {
+        if self.registered && crate::driver::CURRENT.is_set() {
+            crate::driver::CURRENT.with(|inner| inner.unregister_buf_ring(self.buf_group_id))?;
+            self.registered = false;
+        }
+        Ok(())
+    }
+
+    /// Buffer group ID.
+    #[inline]
+    pub fn bgid(&self) -> u16 {
+        self.buf_group_id
+    }
+
+    /// # Safety
+    /// buf_id and len must come from a valid io_uring completion.
+    #[inline]
+    pub(crate) unsafe fn get_buf(&self, buf_id: u16, len: usize) -> RawBuffer<'_> {
+        debug_assert!(buf_id < self.buf_count);
+        debug_assert!(len <= self.buf_len);
+
+        RawBuffer {
+            buf_id,
+            offset: 0,
+            len,
+            ring: self,
+        }
+    }
+
+    /// # Safety
+    /// buf_id, offset, and len must come from a valid io_uring completion.
+    #[inline]
+    unsafe fn get_buf_offset(&self, buf_id: u16, offset: usize, len: usize) -> RawBuffer<'_> {
+        debug_assert!(buf_id < self.buf_count);
+        debug_assert!(offset + len <= self.buf_len);
+
+        RawBuffer {
+            buf_id,
+            offset,
+            len,
+            ring: self,
+        }
+    }
+
+    #[inline]
+    fn return_buffer(&self, buf_id: u16) {
+        let ptr = self.buf_ring_ptr.expect("UserRingBuf already unmapped");
+        let tail = unsafe { self.shared_tail.as_ref() };
+        let local_tail = tail.load(Ordering::Relaxed);
+        let ring_idx = local_tail & (self.ring_entries - 1);
+
+        let entry = unsafe { &mut *ptr.as_ptr().add(ring_idx as usize) };
+        let buf_ptr = unsafe {
+            (*self.data.get())
+                .as_ptr()
+                .add(buf_id as usize * self.buf_len)
+        };
+        entry.set_addr(buf_ptr as u64);
+        entry.set_len(self.buf_len as u32);
+        entry.set_bid(buf_id);
+
+        tail.store(local_tail.wrapping_add(1), Ordering::Release);
+    }
+
+    /// Number of buffers in the ring.
+    #[inline]
+    pub fn buffer_count(&self) -> usize {
+        self.buf_count as usize
+    }
+
+    /// Size of each buffer.
+    #[inline]
+    pub fn buffer_size(&self) -> usize {
+        self.buf_len
+    }
+}
+
+impl Drop for UserRingBuf {
+    fn drop(&mut self) {
+        let _ = self.unregister();
+
+        if let Some(ptr) = self.buf_ring_ptr.take() {
+            unsafe { libc::munmap(ptr.as_ptr() as *mut libc::c_void, self.ring_mmap_size) };
+        }
+    }
+}
+
+impl sealed::Sealed for UserRingBuf {}
+
+impl RingBuf for UserRingBuf {
+    type Buffer<'a> = RawBuffer<'a>;
+
+    #[inline]
+    fn bgid(&self) -> u16 {
+        self.buf_group_id
+    }
+
+    #[inline]
+    fn buffer_size(&self) -> usize {
+        self.buf_len
+    }
+
+    #[inline]
+    fn buffer_count(&self) -> usize {
+        self.buf_count as usize
+    }
+
+    #[inline]
+    unsafe fn get_buf(&self, buf_id: u16, len: usize) -> RawBuffer<'_> {
+        UserRingBuf::get_buf(self, buf_id, len)
+    }
+}
+
+/// Buffer borrowed from a [`UserRingBuf`].
+pub struct RawBuffer<'ring> {
+    buf_id: u16,
+    offset: usize,
+    len: usize,
+    ring: &'ring UserRingBuf,
+}
+
+impl RawBuffer<'_> {
+    /// Buffer ID.
+    #[inline]
+    pub fn id(&self) -> u16 {
+        self.buf_id
+    }
+
+    /// Data length.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether the buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Deref for RawBuffer<'_> {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        let start = self.buf_id as usize * self.ring.buf_len + self.offset;
+        unsafe { &(*self.ring.data.get())[start..start + self.len] }
+    }
+}
+
+impl DerefMut for RawBuffer<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        let start = self.buf_id as usize * self.ring.buf_len + self.offset;
+        unsafe { &mut (*self.ring.data.get())[start..start + self.len] }
+    }
+}
+
+impl AsRef<[u8]> for RawBuffer<'_> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+impl AsMut<[u8]> for RawBuffer<'_> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.deref_mut()
+    }
+}
+
+impl std::fmt::Debug for RawBuffer<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawBuffer")
+            .field("buf_id", &self.buf_id)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+impl Drop for RawBuffer<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.ring.return_buffer(self.buf_id);
+    }
+}
+
+/// Buffer ring for recvmsg with address parsing. See [`UserRingBuf`] for cleanup.
+pub struct UserRecvMsgRingBuf<P: RecvMsgParser> {
+    inner: UserRingBuf,
+    _parser: PhantomData<P>,
+}
+
+impl<P: RecvMsgParser> UserRecvMsgRingBuf<P> {
+    /// Create new recvmsg buffer ring.
+    pub fn new(buf_count: u16, payload_size: usize, group_id: u16) -> io::Result<Self> {
+        let total_size = P::min_buffer_size() + payload_size;
+        let mut inner = UserRingBuf::new(buf_count, total_size as u32, group_id)?;
+        inner.register()?;
+        Ok(Self {
+            inner,
+            _parser: PhantomData,
+        })
+    }
+
+    /// Underlying buffer ring.
+    #[inline]
+    pub fn inner(&self) -> &UserRingBuf {
+        &self.inner
+    }
+
+    /// Buffer group ID.
+    #[inline]
+    pub fn bgid(&self) -> u16 {
+        self.inner.bgid()
+    }
+
+    /// Size of each buffer.
+    #[inline]
+    pub fn buffer_size(&self) -> usize {
+        self.inner.buffer_size()
+    }
+
+    /// Number of buffers.
+    #[inline]
+    pub fn buffer_count(&self) -> usize {
+        self.inner.buffer_count()
+    }
+
+    /// Unregister from io_uring. Does nothing if not registered.
+    pub fn unregister(&mut self) -> io::Result<()> {
+        self.inner.unregister()
+    }
+}
+
+impl<P: RecvMsgParser> sealed::Sealed for UserRecvMsgRingBuf<P> {}
+
+impl<P: RecvMsgParser> RingBuf for UserRecvMsgRingBuf<P> {
+    type Buffer<'a>
+        = RawBuffer<'a>
+    where
+        P: 'a;
+
+    #[inline]
+    fn bgid(&self) -> u16 {
+        self.inner.bgid()
+    }
+
+    #[inline]
+    fn buffer_size(&self) -> usize {
+        self.inner.buffer_size()
+    }
+
+    #[inline]
+    fn buffer_count(&self) -> usize {
+        self.inner.buffer_count()
+    }
+
+    #[inline]
+    unsafe fn get_buf(&self, buf_id: u16, len: usize) -> RawBuffer<'_> {
+        self.inner.get_buf(buf_id, len)
+    }
+}
+
+impl<P: RecvMsgParser + Unpin + 'static> RecvMsgRingBuf for UserRecvMsgRingBuf<P> {
+    type Parser = P;
+
+    #[inline]
+    unsafe fn parse_recvmsg(
+        &self,
+        buf_id: u16,
+        len: usize,
+        msghdr: &libc::msghdr,
+    ) -> io::Result<(P::Address, RawBuffer<'_>)> {
+        debug_assert!(buf_id < self.inner.buf_count);
+        debug_assert!(len <= self.inner.buf_len);
+
+        let start = buf_id as usize * self.inner.buf_len;
+        let raw = &(*self.inner.data.get())[start..start + len];
+        let parsed = io_uring::types::RecvMsgOut::parse(raw, msghdr)
+            .map_err(|()| io::Error::new(io::ErrorKind::InvalidData, "failed to parse recvmsg"))?;
+        let addr = P::parse_address(parsed.name_data())?;
+        let payload_len = parsed.payload_data().len();
+        let header_len = len - payload_len;
+        Ok((
+            addr,
+            self.inner.get_buf_offset(buf_id, header_len, payload_len),
+        ))
+    }
+}

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -191,6 +191,34 @@ impl Inner {
         }
     }
 
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    pub(crate) fn register_buf_ring(
+        &self,
+        ring_addr: u64,
+        ring_entries: u16,
+        bgid: u16,
+    ) -> io::Result<()> {
+        match self {
+            Inner::Uring(this) => {
+                UringInner::register_buf_ring(this, ring_addr, ring_entries, bgid)
+            }
+            #[cfg(feature = "legacy")]
+            Inner::Legacy(_) => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "buffer ring not supported on legacy driver",
+            )),
+        }
+    }
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    pub(crate) fn unregister_buf_ring(&self, bgid: u16) -> io::Result<()> {
+        match self {
+            Inner::Uring(this) => UringInner::unregister_buf_ring(this, bgid),
+            #[cfg(feature = "legacy")]
+            Inner::Legacy(_) => Ok(()),
+        }
+    }
+
     #[cfg(all(target_os = "linux", feature = "iouring", feature = "legacy"))]
     fn is_legacy(&self) -> bool {
         matches!(self, Inner::Legacy(..))

--- a/monoio/src/driver/mod.rs
+++ b/monoio/src/driver/mod.rs
@@ -192,6 +192,44 @@ impl Inner {
     }
 
     #[cfg(all(target_os = "linux", feature = "iouring"))]
+    pub(crate) fn submit_multishot_with<T: OpAble>(
+        &self,
+        data: &mut T,
+        queue_capacity: usize,
+    ) -> io::Result<usize> {
+        match self {
+            Inner::Uring(this) => UringInner::submit_multishot_with(this, data, queue_capacity),
+            #[cfg(feature = "legacy")]
+            Inner::Legacy(_) => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "multishot not supported on legacy driver",
+            )),
+        }
+    }
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    pub(crate) fn poll_multishot_op(
+        &self,
+        index: usize,
+        cx: &mut Context<'_>,
+    ) -> uring::lifecycle::MultishotPollResult {
+        match self {
+            Inner::Uring(this) => UringInner::poll_multishot_op(this, index, cx),
+            #[cfg(feature = "legacy")]
+            Inner::Legacy(_) => uring::lifecycle::MultishotPollResult::Done,
+        }
+    }
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    pub(crate) fn remove_op(&self, index: usize) {
+        match self {
+            Inner::Uring(this) => UringInner::remove_op(this, index),
+            #[cfg(feature = "legacy")]
+            Inner::Legacy(_) => {}
+        }
+    }
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
     pub(crate) fn register_buf_ring(
         &self,
         ring_addr: u64,

--- a/monoio/src/driver/op.rs
+++ b/monoio/src/driver/op.rs
@@ -17,6 +17,8 @@ mod fsync;
 mod open;
 mod poll;
 mod recv;
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub(crate) mod recv_multishot;
 mod send;
 #[cfg(unix)]
 mod statx;
@@ -143,6 +145,8 @@ pub(crate) trait OpAble {
     const RET_IS_FD: bool = false;
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     const SKIP_CANCEL: bool = false;
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const MULTISHOT: bool = false;
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry;
 
@@ -282,5 +286,127 @@ pub(crate) struct OpCanceller {
 impl OpCanceller {
     pub(crate) unsafe fn cancel(&self) {
         super::CURRENT.with(|inner| inner.cancel_op(self))
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub(crate) use multishot::*;
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+mod multishot {
+    use std::{io, task::Poll};
+
+    use super::{driver, MaybeFd, OpAble};
+    use crate::driver::uring::lifecycle::{MultishotPollResult, IORING_CQE_F_BUFFER};
+
+    #[derive(Debug)]
+    pub(crate) struct MultishotCompletion {
+        pub(crate) value: MaybeFd,
+        pub(crate) flags: u32,
+    }
+
+    impl MultishotCompletion {
+        #[inline]
+        pub(crate) fn buffer_id(&self) -> Option<u16> {
+            if self.flags & IORING_CQE_F_BUFFER != 0 {
+                Some((self.flags >> 16) as u16)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub(crate) struct MultishotOp<T: OpAble + Unpin + 'static> {
+        driver: driver::Inner,
+        index: usize,
+        data: Option<T>,
+    }
+
+    impl<T: OpAble + Unpin + 'static> MultishotOp<T> {
+        pub(crate) fn new(mut data: T, queue_capacity: usize) -> io::Result<Self> {
+            let driver = driver::CURRENT.with(|inner| inner.clone());
+            let index = driver.submit_multishot_with(&mut data, queue_capacity)?;
+
+            Ok(Self {
+                driver,
+                index,
+                data: Some(data),
+            })
+        }
+
+        pub(crate) fn is_terminated(&self) -> bool {
+            self.index == usize::MAX
+        }
+
+        pub(crate) fn data(&self) -> Option<&T> {
+            self.data.as_ref()
+        }
+
+        pub(crate) fn data_mut(&mut self) -> Option<&mut T> {
+            self.data.as_mut()
+        }
+
+        pub(crate) fn take_data(&mut self) -> Option<T> {
+            self.data.take()
+        }
+
+        pub(crate) fn op_canceller(&self) -> super::OpCanceller {
+            super::OpCanceller {
+                index: self.index,
+                #[cfg(feature = "legacy")]
+                direction: None,
+            }
+        }
+
+        pub(crate) fn poll_next(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Option<io::Result<MultishotCompletion>>> {
+            if self.index == usize::MAX {
+                return Poll::Ready(None);
+            }
+
+            match self.driver.poll_multishot_op(self.index, cx) {
+                MultishotPollResult::Ready(cqe) => {
+                    let completion = cqe.result.map(|value| MultishotCompletion {
+                        value,
+                        flags: cqe.flags,
+                    });
+                    Poll::Ready(Some(completion))
+                }
+
+                MultishotPollResult::Terminated(cqe) => {
+                    self.driver.remove_op(self.index);
+                    self.index = usize::MAX;
+
+                    let completion = cqe.result.map(|value| MultishotCompletion {
+                        value,
+                        flags: cqe.flags,
+                    });
+                    Poll::Ready(Some(completion))
+                }
+
+                MultishotPollResult::Done => {
+                    self.driver.remove_op(self.index);
+                    self.index = usize::MAX;
+                    Poll::Ready(None)
+                }
+
+                MultishotPollResult::Pending => Poll::Pending,
+            }
+        }
+
+        pub(crate) async fn poll_next_async(&mut self) -> Option<io::Result<MultishotCompletion>> {
+            std::future::poll_fn(|cx| self.poll_next(cx)).await
+        }
+    }
+
+    impl<T: OpAble + Unpin + 'static> Drop for MultishotOp<T> {
+        fn drop(&mut self) {
+            if self.index != usize::MAX {
+                self.driver
+                    .drop_op(self.index, &mut self.data, T::SKIP_CANCEL);
+            }
+        }
     }
 }

--- a/monoio/src/driver/op/recv_multishot.rs
+++ b/monoio/src/driver/op/recv_multishot.rs
@@ -1,0 +1,97 @@
+//! Multishot receive operations for io_uring.
+
+use std::io;
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+use io_uring::{opcode, types};
+
+use super::{super::shared_fd::SharedFd, OpAble};
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use super::{driver::ready::Direction, MaybeFd};
+use crate::buf::RecvMsgParser;
+
+/// Multishot recv operation for connected sockets.
+pub(crate) struct RecvMultishotOp {
+    fd: SharedFd,
+    bgid: u16,
+}
+
+impl RecvMultishotOp {
+    pub(crate) fn new(fd: SharedFd, bgid: u16) -> Self {
+        Self { fd, bgid }
+    }
+}
+
+impl OpAble for RecvMultishotOp {
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const MULTISHOT: bool = true;
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const SKIP_CANCEL: bool = false;
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        opcode::RecvMulti::new(types::Fd(self.fd.raw_fd()), self.bgid).build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_interest(&self) -> Option<(Direction, usize)> {
+        self.fd.registered_index().map(|idx| (Direction::Read, idx))
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "multishot recv not supported on legacy driver",
+        ))
+    }
+}
+
+/// Multishot recvmsg operation with address parsing.
+pub(crate) struct RecvMsgMultishotOp {
+    fd: SharedFd,
+    pub(crate) msghdr: Box<libc::msghdr>,
+    bgid: u16,
+}
+
+impl RecvMsgMultishotOp {
+    pub(crate) fn new<P: RecvMsgParser>(fd: SharedFd, bgid: u16) -> Self {
+        let mut msghdr: libc::msghdr = unsafe { std::mem::zeroed() };
+        msghdr.msg_namelen = P::NAME_LEN;
+        Self {
+            fd,
+            msghdr: Box::new(msghdr),
+            bgid,
+        }
+    }
+}
+
+impl OpAble for RecvMsgMultishotOp {
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const MULTISHOT: bool = true;
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const SKIP_CANCEL: bool = false;
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        opcode::RecvMsgMulti::new(
+            types::Fd(self.fd.raw_fd()),
+            &*self.msghdr as *const _,
+            self.bgid,
+        )
+        .build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_interest(&self) -> Option<(Direction, usize)> {
+        self.fd.registered_index().map(|idx| (Direction::Read, idx))
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "multishot recvmsg not supported on legacy driver",
+        ))
+    }
+}

--- a/monoio/src/driver/uring/lifecycle.rs
+++ b/monoio/src/driver/uring/lifecycle.rs
@@ -2,6 +2,7 @@
 //! Partly borrow from tokio-uring.
 
 use std::{
+    collections::VecDeque,
     io,
     task::{Context, Poll, Waker},
 };
@@ -10,6 +11,24 @@ use crate::{
     driver::op::{CompletionMeta, MaybeFd},
     utils::slab::Ref,
 };
+
+pub(crate) const IORING_CQE_F_BUFFER: u32 = 1 << 0;
+pub(crate) const IORING_CQE_F_MORE: u32 = 1 << 1;
+
+#[derive(Debug)]
+pub(crate) struct MultishotCqe {
+    pub result: io::Result<MaybeFd>,
+    pub flags: u32,
+    pub is_final: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum MultishotPollResult {
+    Ready(MultishotCqe),
+    Terminated(MultishotCqe),
+    Pending,
+    Done,
+}
 
 enum Lifecycle {
     /// The operation has been submitted to uring and is currently in-flight
@@ -25,6 +44,13 @@ enum Lifecycle {
 
     /// The operation has completed.
     Completed(io::Result<MaybeFd>, u32),
+
+    /// Active multishot operation with queued completions
+    Multishot {
+        queue: VecDeque<MultishotCqe>,
+        waker: Option<Waker>,
+        terminated: bool,
+    },
 }
 
 pub(crate) struct MaybeFdLifecycle {
@@ -40,30 +66,67 @@ impl MaybeFdLifecycle {
             lifecycle: Lifecycle::Submitted,
         }
     }
+
+    #[inline]
+    pub(crate) fn new_multishot(queue_capacity: usize, is_fd: bool) -> Self {
+        Self {
+            is_fd,
+            lifecycle: Lifecycle::Multishot {
+                queue: VecDeque::with_capacity(queue_capacity),
+                waker: None,
+                terminated: false,
+            },
+        }
+    }
 }
 
 impl Ref<'_, MaybeFdLifecycle> {
-    // # Safety
-    // Caller must make sure the result is valid since it may contain fd or a length hint.
+    /// # Safety
+    /// Caller must make sure the result is valid since it may contain fd or a length hint.
     pub(crate) unsafe fn complete(mut self, result: io::Result<u32>, flags: u32) {
-        let result = MaybeFd::new_result(result, self.is_fd);
-        let ref_mut = &mut self.lifecycle;
-        match ref_mut {
+        let is_final = (flags & IORING_CQE_F_MORE) == 0;
+        let is_fd = self.is_fd;
+
+        match &mut self.lifecycle {
             Lifecycle::Submitted => {
-                *ref_mut = Lifecycle::Completed(result, flags);
+                let result = MaybeFd::new_result(result, is_fd);
+                self.lifecycle = Lifecycle::Completed(result, flags);
             }
+
             Lifecycle::Waiting(_) => {
-                let old = std::mem::replace(ref_mut, Lifecycle::Completed(result, flags));
-                match old {
-                    Lifecycle::Waiting(waker) => {
-                        waker.wake();
-                    }
-                    _ => std::hint::unreachable_unchecked(),
+                let result = MaybeFd::new_result(result, is_fd);
+                let old =
+                    std::mem::replace(&mut self.lifecycle, Lifecycle::Completed(result, flags));
+                if let Lifecycle::Waiting(waker) = old {
+                    waker.wake();
                 }
             }
-            Lifecycle::Ignored(..) => {
-                self.remove();
+
+            Lifecycle::Multishot {
+                queue,
+                waker,
+                terminated,
+            } => {
+                queue.push_back(MultishotCqe {
+                    result: MaybeFd::new_result(result, is_fd),
+                    flags,
+                    is_final,
+                });
+                if is_final {
+                    *terminated = true;
+                }
+                if let Some(w) = waker.take() {
+                    w.wake();
+                }
             }
+
+            Lifecycle::Ignored(..) => {
+                let _drop_fd = MaybeFd::new_result(result, is_fd);
+                if is_final {
+                    self.remove();
+                }
+            }
+
             Lifecycle::Completed(..) => std::hint::unreachable_unchecked(),
         }
     }
@@ -91,24 +154,59 @@ impl Ref<'_, MaybeFdLifecycle> {
         }
     }
 
-    // return if the op must has been finished
     pub(crate) fn drop_op<T: 'static>(mut self, data: &mut Option<T>) -> bool {
         let ref_mut = &mut self.lifecycle;
-        match ref_mut {
-            Lifecycle::Submitted | Lifecycle::Waiting(_) => {
-                if let Some(data) = data.take() {
-                    *ref_mut = Lifecycle::Ignored(Box::new(data));
-                } else {
-                    *ref_mut = Lifecycle::Ignored(Box::new(())); // () is a ZST, so it does not
-                                                                 // allocate
-                };
-                return false;
-            }
-            Lifecycle::Completed(..) => {
-                self.remove();
-            }
+        let terminated = match ref_mut {
+            Lifecycle::Submitted | Lifecycle::Waiting(_) => false,
+            Lifecycle::Completed(..) => true,
+            Lifecycle::Multishot { terminated, .. } => *terminated,
             Lifecycle::Ignored(..) => unsafe { std::hint::unreachable_unchecked() },
+        };
+
+        if terminated {
+            self.remove();
+            true
+        } else {
+            let boxed: Box<dyn std::any::Any> = if let Some(d) = data.take() {
+                Box::new(d)
+            } else {
+                Box::new(())
+            };
+            *ref_mut = Lifecycle::Ignored(boxed);
+            false
         }
-        true
+    }
+
+    pub(crate) fn poll_multishot(mut self, cx: &mut Context<'_>) -> MultishotPollResult {
+        let ref_mut = &mut self.lifecycle;
+
+        match ref_mut {
+            Lifecycle::Multishot {
+                queue,
+                waker,
+                terminated,
+            } => {
+                if let Some(cqe) = queue.pop_front() {
+                    let is_final = cqe.is_final;
+
+                    if *terminated && queue.is_empty() {
+                        return MultishotPollResult::Terminated(cqe);
+                    }
+
+                    if is_final {
+                        MultishotPollResult::Terminated(cqe)
+                    } else {
+                        MultishotPollResult::Ready(cqe)
+                    }
+                } else if *terminated {
+                    MultishotPollResult::Done
+                } else {
+                    *waker = Some(cx.waker().clone());
+                    MultishotPollResult::Pending
+                }
+            }
+
+            _ => MultishotPollResult::Done,
+        }
     }
 }

--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -554,6 +554,29 @@ impl UringInner {
         let weak = std::sync::Arc::downgrade(&inner.shared_waker);
         waker::UnparkHandle(weak)
     }
+
+    pub(crate) fn register_buf_ring(
+        this: &Rc<UnsafeCell<UringInner>>,
+        ring_addr: u64,
+        ring_entries: u16,
+        bgid: u16,
+    ) -> io::Result<()> {
+        let inner = unsafe { &mut *this.get() };
+        unsafe {
+            inner
+                .uring
+                .submitter()
+                .register_buf_ring(ring_addr, ring_entries, bgid)
+        }
+    }
+
+    pub(crate) fn unregister_buf_ring(
+        this: &Rc<UnsafeCell<UringInner>>,
+        bgid: u16,
+    ) -> io::Result<()> {
+        let inner = unsafe { &mut *this.get() };
+        inner.uring.submitter().unregister_buf_ring(bgid)
+    }
 }
 
 impl AsRawFd for IoUringDriver {

--- a/monoio/src/driver/uring/mod.rs
+++ b/monoio/src/driver/uring/mod.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use io_uring::{cqueue, opcode, types::Timespec, IoUring};
-use lifecycle::MaybeFdLifecycle;
+use lifecycle::{MaybeFdLifecycle, MultishotPollResult};
 
 use super::{
     op::{CompletionMeta, Op, OpAble},
@@ -24,7 +24,7 @@ use super::{
 };
 use crate::utils::slab::Slab;
 
-mod lifecycle;
+pub(crate) mod lifecycle;
 #[cfg(feature = "sync")]
 mod waker;
 #[cfg(feature = "sync")]
@@ -382,6 +382,7 @@ impl UringInner {
 
         for cqe in cq {
             let index = cqe.user_data();
+            let flags = cqe.flags();
             match index {
                 #[cfg(feature = "sync")]
                 EVENTFD_USERDATA => self.eventfd_installed = false,
@@ -393,7 +394,7 @@ impl UringInner {
                 _ if index >= MIN_REVERSED_USERDATA => (),
                 // # Safety
                 // Here we can make sure the result is valid.
-                _ => unsafe { self.ops.complete(index as _, resultify(&cqe), cqe.flags()) },
+                _ => unsafe { self.ops.complete(index as _, resultify(&cqe), flags) },
             }
         }
         Ok(())
@@ -426,7 +427,7 @@ impl UringInner {
     fn new_op<T: OpAble>(data: T, inner: &mut UringInner, driver: Inner) -> Op<T> {
         Op {
             driver,
-            index: inner.ops.insert(T::RET_IS_FD),
+            index: inner.ops.insert::<T>(),
             data: Some(data),
         }
     }
@@ -515,7 +516,6 @@ impl UringInner {
     ) {
         let inner = unsafe { &mut *this.get() };
         if index == usize::MAX {
-            // already finished
             return;
         }
         if let Some(lifecycle) = inner.ops.slab.get(index) {
@@ -527,7 +527,6 @@ impl UringInner {
                         .build()
                         .user_data(u64::MAX);
 
-                    // Try push cancel, if failed, will submit and re-push.
                     if inner.uring.submission().push(&cancel).is_err() {
                         let _ = inner.submit();
                         let _ = inner.uring.submission().push(&cancel);
@@ -553,6 +552,47 @@ impl UringInner {
         let inner = unsafe { &*this.get() };
         let weak = std::sync::Arc::downgrade(&inner.shared_waker);
         waker::UnparkHandle(weak)
+    }
+
+    pub(crate) fn submit_multishot_with<T>(
+        this: &Rc<UnsafeCell<UringInner>>,
+        data: &mut T,
+        queue_capacity: usize,
+    ) -> io::Result<usize>
+    where
+        T: OpAble,
+    {
+        let inner = unsafe { &mut *this.get() };
+        if inner.uring.submission().is_full() {
+            inner.submit()?;
+        }
+
+        let index = inner.ops.insert_multishot(queue_capacity, T::RET_IS_FD);
+        let sqe = OpAble::uring_op(data).user_data(index as _);
+
+        {
+            let mut sq = inner.uring.submission();
+            if unsafe { sq.push(&sqe).is_err() } {
+                inner.ops.remove(index);
+                return Err(io::Error::other("submission queue full"));
+            }
+        }
+
+        Ok(index)
+    }
+
+    pub(crate) fn poll_multishot_op(
+        this: &Rc<UnsafeCell<UringInner>>,
+        index: usize,
+        cx: &mut Context<'_>,
+    ) -> MultishotPollResult {
+        let inner = unsafe { &mut *this.get() };
+        inner.ops.poll_multishot(index, cx)
+    }
+
+    pub(crate) fn remove_op(this: &Rc<UnsafeCell<UringInner>>, index: usize) {
+        let inner = unsafe { &mut *this.get() };
+        inner.ops.remove(index);
     }
 
     pub(crate) fn register_buf_ring(
@@ -622,19 +662,37 @@ impl Ops {
         Ops { slab: Slab::new() }
     }
 
-    // Insert a new operation
     #[inline]
-    pub(crate) fn insert(&mut self, is_fd: bool) -> usize {
-        self.slab.insert(MaybeFdLifecycle::new(is_fd))
+    pub(crate) fn insert<T: OpAble>(&mut self) -> usize {
+        self.slab.insert(MaybeFdLifecycle::new(T::RET_IS_FD))
     }
 
-    // Complete an operation
-    // # Safety
-    // Caller must make sure the result is valid.
+    #[inline]
+    pub(crate) fn insert_multishot(&mut self, queue_capacity: usize, is_fd: bool) -> usize {
+        self.slab
+            .insert(MaybeFdLifecycle::new_multishot(queue_capacity, is_fd))
+    }
+
+    /// # Safety
+    /// Caller must make sure the result is valid.
     #[inline]
     unsafe fn complete(&mut self, index: usize, result: io::Result<u32>, flags: u32) {
         let lifecycle = unsafe { self.slab.get(index).unwrap_unchecked() };
         lifecycle.complete(result, flags);
+    }
+
+    #[inline]
+    fn poll_multishot(&mut self, index: usize, cx: &mut Context<'_>) -> MultishotPollResult {
+        if let Some(lifecycle) = self.slab.get(index) {
+            lifecycle.poll_multishot(cx)
+        } else {
+            MultishotPollResult::Done
+        }
+    }
+
+    #[inline]
+    fn remove(&mut self, index: usize) {
+        let _ = self.slab.remove(index);
     }
 }
 

--- a/monoio/src/io/mod.rs
+++ b/monoio/src/io/mod.rs
@@ -29,13 +29,13 @@ mod util;
 
 #[cfg(feature = "poll-io")]
 pub use tokio::io as poll_io;
-pub(crate) use util::operation_canceled;
 #[cfg(all(target_os = "linux", feature = "splice"))]
 pub use util::zero_copy;
 pub use util::{
     copy, BufReader, BufWriter, CancelHandle, Canceller, OwnedReadHalf, OwnedWriteHalf,
     PrefixedReadIo, Split, Splitable,
 };
+pub(crate) use util::{is_operation_canceled, operation_canceled, AssociateGuard};
 #[cfg(feature = "poll-io")]
 /// Convert a completion-based io to a poll-based io.
 pub trait IntoPollIo: Sized {

--- a/monoio/src/io/util/cancel.rs
+++ b/monoio/src/io/util/cancel.rs
@@ -89,5 +89,9 @@ impl Drop for AssociateGuard {
 }
 
 pub(crate) fn operation_canceled() -> std::io::Error {
-    std::io::Error::from_raw_os_error(125)
+    std::io::Error::from_raw_os_error(libc::ECANCELED)
+}
+
+pub(crate) fn is_operation_canceled(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::ECANCELED)
 }

--- a/monoio/src/io/util/mod.rs
+++ b/monoio/src/io/util/mod.rs
@@ -9,7 +9,7 @@ mod split;
 
 pub use buf_reader::BufReader;
 pub use buf_writer::BufWriter;
-pub(crate) use cancel::operation_canceled;
+pub(crate) use cancel::{is_operation_canceled, operation_canceled, AssociateGuard};
 pub use cancel::{CancelHandle, Canceller};
 pub use copy::copy;
 #[cfg(all(target_os = "linux", feature = "splice"))]

--- a/monoio/src/net/udp.rs
+++ b/monoio/src/net/udp.rs
@@ -248,6 +248,271 @@ impl AsRawSocket for UdpSocket {
     }
 }
 
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+mod multishot_impl {
+    use std::io;
+
+    use super::UdpSocket;
+    use crate::{
+        buf::{RecvMsgParser, RecvMsgRingBuf, RingBuf},
+        driver::op::{
+            recv_multishot::{RecvMsgMultishotOp, RecvMultishotOp},
+            MultishotOp,
+        },
+        io::{is_operation_canceled, AssociateGuard, CancelHandle},
+    };
+
+    /// Multishot recv for connected sockets.
+    ///
+    /// Call [`stream()`](Self::stream) to get a [`RecvMultishotStream`] for receiving buffers.
+    pub struct RecvMultishot<R: RingBuf + Unpin + 'static> {
+        ring: R,
+        op: MultishotOp<RecvMultishotOp>,
+        cancellation_guard: Option<AssociateGuard>,
+    }
+
+    /// Stream for receiving buffers from a [`RecvMultishot`] operation.
+    ///
+    /// Holds a mutable borrow of the parent, preventing concurrent polling.
+    /// Buffers returned by `next()` can be held across multiple calls.
+    pub struct RecvMultishotStream<'a, R: RingBuf + Unpin + 'static> {
+        ring: &'a R,
+        op: &'a mut MultishotOp<RecvMultishotOp>,
+        cancellation_guard: &'a Option<AssociateGuard>,
+    }
+
+    impl<R: RingBuf + Unpin + 'static> RecvMultishot<R> {
+        /// Creates a stream for receiving buffers.
+        ///
+        /// The stream holds a mutable borrow, preventing concurrent polling.
+        /// Buffers returned by the stream can outlive individual `next()` calls.
+        #[inline]
+        pub fn stream(&mut self) -> RecvMultishotStream<'_, R> {
+            RecvMultishotStream {
+                ring: &self.ring,
+                op: &mut self.op,
+                cancellation_guard: &self.cancellation_guard,
+            }
+        }
+
+        /// Returns whether the multishot operation has terminated.
+        #[inline]
+        pub fn is_terminated(&self) -> bool {
+            self.op.is_terminated()
+        }
+
+        /// Attempts to consume and return the buffer ring.
+        ///
+        /// Returns `Ok(ring)` if the multishot operation has terminated.
+        /// Returns `Err(self)` if the operation is still in progress.
+        pub fn try_into_ring(self) -> Result<R, Self> {
+            if self.op.is_terminated() {
+                Ok(self.ring)
+            } else {
+                Err(self)
+            }
+        }
+    }
+
+    impl<'a, R: RingBuf + Unpin + 'static> RecvMultishotStream<'a, R> {
+        /// Receives the next buffer.
+        ///
+        /// Returns `None` when the operation is terminated or cancelled.
+        /// The returned buffer has lifetime `'a`, allowing multiple buffers
+        /// to be held simultaneously across `next()` calls.
+        pub async fn next(&mut self) -> Option<io::Result<R::Buffer<'a>>> {
+            let completion = match self.op.poll_next_async().await? {
+                Ok(c) => c,
+                Err(e) => {
+                    if self.cancellation_guard.is_some() && is_operation_canceled(&e) {
+                        return None;
+                    }
+                    return Some(Err(e));
+                }
+            };
+
+            let buf_id = match completion.buffer_id() {
+                Some(id) => id,
+                None => {
+                    return Some(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "multishot completion missing buffer ID",
+                    )))
+                }
+            };
+
+            let len = completion.value.into_inner() as usize;
+            Some(Ok(unsafe { self.ring.get_buf(buf_id, len) }))
+        }
+    }
+
+    /// Multishot recvmsg yielding `(Address, Buffer)` pairs.
+    ///
+    /// Call [`stream()`](Self::stream) to get a [`RecvMsgMultishotStream`] for receiving messages.
+    pub struct RecvMsgMultishot<R: RecvMsgRingBuf + Unpin + 'static> {
+        ring: R,
+        op: MultishotOp<RecvMsgMultishotOp>,
+        cancellation_guard: Option<AssociateGuard>,
+    }
+
+    /// Stream for receiving messages from a [`RecvMsgMultishot`] operation.
+    ///
+    /// Holds a mutable borrow of the parent, preventing concurrent polling.
+    /// Buffers returned by `next()` can be held across multiple calls.
+    pub struct RecvMsgMultishotStream<'a, R: RecvMsgRingBuf + Unpin + 'static> {
+        ring: &'a R,
+        op: &'a mut MultishotOp<RecvMsgMultishotOp>,
+        cancellation_guard: &'a Option<AssociateGuard>,
+    }
+
+    impl<R: RecvMsgRingBuf + Unpin + 'static> RecvMsgMultishot<R> {
+        /// Creates a stream for receiving messages.
+        ///
+        /// The stream holds a mutable borrow, preventing concurrent polling.
+        /// Buffers returned by the stream can outlive individual `next()` calls.
+        #[inline]
+        pub fn stream(&mut self) -> RecvMsgMultishotStream<'_, R> {
+            RecvMsgMultishotStream {
+                ring: &self.ring,
+                op: &mut self.op,
+                cancellation_guard: &self.cancellation_guard,
+            }
+        }
+
+        /// Returns whether the multishot operation has terminated.
+        #[inline]
+        pub fn is_terminated(&self) -> bool {
+            self.op.is_terminated()
+        }
+
+        /// Attempts to consume and return the buffer ring.
+        ///
+        /// Returns `Ok(ring)` if the multishot operation has terminated.
+        /// Returns `Err(self)` if the operation is still in progress.
+        pub fn try_into_ring(self) -> Result<R, Self> {
+            if self.op.is_terminated() {
+                Ok(self.ring)
+            } else {
+                Err(self)
+            }
+        }
+    }
+
+    impl<'a, R: RecvMsgRingBuf + Unpin + 'static> RecvMsgMultishotStream<'a, R> {
+        /// Receives the next `(address, buffer)` pair.
+        ///
+        /// Returns `None` when the operation is terminated or cancelled.
+        pub async fn next(
+            &mut self,
+        ) -> Option<io::Result<(<R::Parser as RecvMsgParser>::Address, R::Buffer<'a>)>> {
+            let completion = match self.op.poll_next_async().await? {
+                Ok(c) => c,
+                Err(e) => {
+                    if self.cancellation_guard.is_some() && is_operation_canceled(&e) {
+                        return None;
+                    }
+                    return Some(Err(e));
+                }
+            };
+
+            let buf_id = match completion.buffer_id() {
+                Some(id) => id,
+                None => {
+                    return Some(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "multishot completion missing buffer ID",
+                    )))
+                }
+            };
+
+            let total_len = completion.value.into_inner() as usize;
+            let msghdr: &libc::msghdr = &self.op.data().expect("op data").msghdr;
+
+            let (addr, buf) = match unsafe { self.ring.parse_recvmsg(buf_id, total_len, msghdr) } {
+                Ok(result) => result,
+                Err(e) => return Some(Err(e)),
+            };
+
+            Some(Ok((addr, buf)))
+        }
+    }
+
+    impl UdpSocket {
+        /// Multishot recv for connected sockets. Socket must be connected first.
+        pub fn recv_multishot<R: RingBuf + Unpin + 'static>(
+            &self,
+            ring: R,
+        ) -> io::Result<RecvMultishot<R>> {
+            let buf_count = ring.buffer_count();
+            let bgid = ring.bgid();
+            let op = RecvMultishotOp::new(self.fd.clone(), bgid);
+            let op = MultishotOp::new(op, buf_count)?;
+            Ok(RecvMultishot {
+                ring,
+                op,
+                cancellation_guard: None,
+            })
+        }
+
+        /// Multishot recv with cancellation support.
+        pub fn cancelable_recv_multishot<R: RingBuf + Unpin + 'static>(
+            &self,
+            ring: R,
+            c: CancelHandle,
+        ) -> io::Result<RecvMultishot<R>> {
+            let buf_count = ring.buffer_count();
+            let bgid = ring.bgid();
+            let op = RecvMultishotOp::new(self.fd.clone(), bgid);
+            let op = MultishotOp::new(op, buf_count)?;
+            let cancellation_guard = c.associate_op(op.op_canceller());
+            Ok(RecvMultishot {
+                ring,
+                op,
+                cancellation_guard: Some(cancellation_guard),
+            })
+        }
+
+        /// Multishot recvmsg returning sender address and payload.
+        pub fn recvmsg_multishot<R: RecvMsgRingBuf + Unpin + 'static>(
+            &self,
+            ring: R,
+        ) -> io::Result<RecvMsgMultishot<R>> {
+            let buf_count = ring.buffer_count();
+            let bgid = ring.bgid();
+            let op = RecvMsgMultishotOp::new::<R::Parser>(self.fd.clone(), bgid);
+            let op = MultishotOp::new(op, buf_count)?;
+            Ok(RecvMsgMultishot {
+                ring,
+                op,
+                cancellation_guard: None,
+            })
+        }
+
+        /// Multishot recvmsg with cancellation support.
+        pub fn cancelable_recvmsg_multishot<R: RecvMsgRingBuf + Unpin + 'static>(
+            &self,
+            ring: R,
+            c: CancelHandle,
+        ) -> io::Result<RecvMsgMultishot<R>> {
+            let buf_count = ring.buffer_count();
+            let bgid = ring.bgid();
+            let op = RecvMsgMultishotOp::new::<R::Parser>(self.fd.clone(), bgid);
+            let op = MultishotOp::new(op, buf_count)?;
+            let cancellation_guard = c.associate_op(op.op_canceller());
+            Ok(RecvMsgMultishot {
+                ring,
+                op,
+                cancellation_guard: Some(cancellation_guard),
+            })
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub use multishot_impl::{
+    RecvMsgMultishot, RecvMsgMultishotStream, RecvMultishot, RecvMultishotStream,
+};
+
 /// Cancelable related methods
 impl UdpSocket {
     /// Receives a single datagram message on the socket. On success, returns the number

--- a/monoio/tests/udp.rs
+++ b/monoio/tests/udp.rs
@@ -96,3 +96,432 @@ async fn cancel_recv_from() {
         }
     }
 }
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+mod multishot_tests {
+    use std::net::SocketAddr;
+
+    use monoio::{
+        buf::{
+            AnyRecvMsgParser, Ipv4RecvMsgParser, Ipv6RecvMsgParser, RecvMsgParser,
+            UserRecvMsgRingBuf, UserRingBufBuilder,
+        },
+        io::Canceller,
+        net::udp::{RecvMsgMultishot, UdpSocket},
+    };
+
+    const PAYLOAD_SIZE: usize = 1500;
+
+    async fn test_recvmsg_multishot<P>(
+        recv: &mut RecvMsgMultishot<UserRecvMsgRingBuf<P>>,
+        sender: &UdpSocket,
+        receiver_addr: SocketAddr,
+        sender_addr: SocketAddr,
+    ) where
+        P: RecvMsgParser + Unpin + 'static,
+        P::Address: Into<SocketAddr> + std::fmt::Debug,
+    {
+        let mut stream = recv.stream();
+
+        sender.send_to(b"hello", receiver_addr).await.0.unwrap();
+        {
+            let (addr, buf) = stream.next().await.unwrap().unwrap();
+            assert_eq!(addr.into(), sender_addr);
+            assert_eq!(&*buf, b"hello");
+        }
+
+        sender.send_to(b"world", receiver_addr).await.0.unwrap();
+        {
+            let (addr, buf) = stream.next().await.unwrap().unwrap();
+            assert_eq!(addr.into(), sender_addr);
+            assert_eq!(&*buf, b"world");
+        }
+
+        let large_payload: Vec<u8> = (0..PAYLOAD_SIZE).map(|i| (i % 256) as u8).collect();
+        let (result, _) = sender.send_to(large_payload.clone(), receiver_addr).await;
+        result.unwrap();
+
+        {
+            let (addr, buf) = stream.next().await.unwrap().unwrap();
+            assert_eq!(addr.into(), sender_addr);
+            assert_eq!(buf.len(), PAYLOAD_SIZE);
+            assert_eq!(&*buf, &large_payload[..]);
+        }
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_ipv4() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(16, PAYLOAD_SIZE, 0).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        test_recvmsg_multishot(&mut stream, &sender, receiver_addr, sender_addr).await;
+
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_ipv6() {
+        let receiver = UdpSocket::bind("[::1]:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("[::1]:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv6RecvMsgParser>::new(16, PAYLOAD_SIZE, 1).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        test_recvmsg_multishot(&mut stream, &sender, receiver_addr, sender_addr).await;
+
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_any() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<AnyRecvMsgParser>::new(16, PAYLOAD_SIZE, 2).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        test_recvmsg_multishot(&mut stream, &sender, receiver_addr, sender_addr).await;
+
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_multishot_buffer_reuse() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(4, 64, 30).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        for i in 0..8 {
+            let msg = format!("message {}", i);
+            sender
+                .send_to(msg.clone().into_bytes(), receiver_addr)
+                .await
+                .0
+                .unwrap();
+
+            let (addr, buf) = stream.stream().next().await.unwrap().unwrap();
+            assert_eq!(SocketAddr::from(addr), sender_addr);
+            assert_eq!(&*buf, msg.as_bytes());
+        }
+
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_multishot_buffer_exhaustion_and_recovery() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(4, 64, 60).unwrap();
+        let mut stream = receiver.recvmsg_multishot(ring).unwrap();
+
+        // Send 4 messages, then receive them all
+        for i in 0..4 {
+            sender
+                .send_to(format!("msg{}", i).into_bytes(), receiver_addr)
+                .await
+                .0
+                .unwrap();
+        }
+
+        // Receive all 4 buffers - use a single poller to hold buffers across next() calls
+        let mut poller = stream.stream();
+        let mut held_buffers = Vec::new();
+        for _ in 0..4 {
+            let (_addr, buf) = poller.next().await.unwrap().unwrap();
+            held_buffers.push(buf);
+        }
+
+        // send another message - kernel socket buffer receives it, but io_uring
+        // can't deliver it because no buffers are available in the ring
+        sender
+            .send_to(b"overflow".to_vec(), receiver_addr)
+            .await
+            .0
+            .unwrap();
+
+        // this should fail with ENOBUFS - the buffer ring is exhausted
+        let result = poller.next().await.unwrap();
+        assert!(
+            result.is_err(),
+            "expected ENOBUFS error when ring exhausted"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOBUFS));
+
+        // stream is terminated after ENOBUFS, subsequent calls return None
+        {
+            let result = poller.next().await;
+            assert!(
+                result.is_none(),
+                "stream should be terminated after ENOBUFS"
+            );
+        }
+        drop(held_buffers);
+        drop(poller);
+
+        let ring = stream.try_into_ring().ok().expect("failed to get ring");
+        let canceller = Canceller::new();
+        let mut stream2 = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        // The "overflow" packet is still in the kernel socket buffer
+        {
+            let (addr, buf) = stream2.stream().next().await.unwrap().unwrap();
+            assert_eq!(SocketAddr::from(addr), sender_addr);
+            assert_eq!(&*buf, b"overflow");
+        }
+
+        canceller.cancel();
+        while stream2.stream().next().await.is_some() {}
+        stream2.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_multishot_multiple_senders() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+
+        let sender1 = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender1_addr = sender1.local_addr().unwrap();
+        let sender2 = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender2_addr = sender2.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(16, PAYLOAD_SIZE, 40).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        sender1
+            .send_to(b"from sender1", receiver_addr)
+            .await
+            .0
+            .unwrap();
+        sender2
+            .send_to(b"from sender2", receiver_addr)
+            .await
+            .0
+            .unwrap();
+
+        let mut received_from_1 = false;
+        let mut received_from_2 = false;
+
+        for _ in 0..2 {
+            let (addr, buf) = stream.stream().next().await.unwrap().unwrap();
+            let addr: SocketAddr = addr.into();
+            if addr == sender1_addr {
+                assert_eq!(&*buf, b"from sender1");
+                received_from_1 = true;
+            } else if addr == sender2_addr {
+                assert_eq!(&*buf, b"from sender2");
+                received_from_2 = true;
+            }
+        }
+
+        assert!(received_from_1, "should have received from sender1");
+        assert!(received_from_2, "should have received from sender2");
+
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_multishot_sequential_messages() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(32, 64, 50).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        const NUM_MESSAGES: usize = 20;
+
+        for i in 0..NUM_MESSAGES {
+            let msg = format!("seq{:04}", i);
+            sender
+                .send_to(msg.clone().into_bytes(), receiver_addr)
+                .await
+                .0
+                .unwrap();
+
+            let (addr, buf) = stream.stream().next().await.unwrap().unwrap();
+            assert_eq!(SocketAddr::from(addr), sender_addr);
+            assert_eq!(&*buf, msg.as_bytes());
+        }
+
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recv_multishot_cancel() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+
+        receiver
+            .connect(sender.local_addr().unwrap())
+            .await
+            .unwrap();
+        sender.connect(receiver_addr).await.unwrap();
+
+        let ring = UserRingBufBuilder::new()
+            .buffer_size(PAYLOAD_SIZE)
+            .buffer_count(16)
+            .group_id(60)
+            .build()
+            .unwrap();
+
+        let canceller = Canceller::new();
+        let handle = canceller.handle();
+        let mut stream = receiver.cancelable_recv_multishot(ring, handle).unwrap();
+
+        sender.send(b"hello before cancel").await.0.unwrap();
+
+        {
+            let buf = stream.stream().next().await.unwrap().unwrap();
+            assert_eq!(&*buf, b"hello before cancel");
+        }
+
+        canceller.cancel();
+
+        assert!(stream.stream().next().await.is_none());
+        assert!(stream.stream().next().await.is_none());
+
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn recvmsg_multishot_cancel() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(16, PAYLOAD_SIZE, 50).unwrap();
+
+        let canceller = Canceller::new();
+        let handle = canceller.handle();
+        let mut stream = receiver.cancelable_recvmsg_multishot(ring, handle).unwrap();
+
+        sender
+            .send_to(b"hello before cancel", receiver_addr)
+            .await
+            .0
+            .unwrap();
+
+        {
+            let (addr, buf) = stream.stream().next().await.unwrap().unwrap();
+            assert_eq!(SocketAddr::from(addr), sender_addr);
+            assert_eq!(&*buf, b"hello before cancel");
+        }
+
+        canceller.cancel();
+
+        assert!(stream.stream().next().await.is_none());
+        assert!(stream.stream().next().await.is_none());
+
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+
+    #[monoio::test(driver = "uring")]
+    async fn buffer_ring_held_buffers_not_overwritten() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let receiver_addr = receiver.local_addr().unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+
+        let ring = UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(4, 64, 70).unwrap();
+        let canceller = Canceller::new();
+        let mut stream = receiver
+            .cancelable_recvmsg_multishot(ring, canceller.handle())
+            .unwrap();
+
+        let mut poller = stream.stream();
+
+        sender
+            .send_to(b"held_aaa".to_vec(), receiver_addr)
+            .await
+            .0
+            .unwrap();
+        sender
+            .send_to(b"held_bbb".to_vec(), receiver_addr)
+            .await
+            .0
+            .unwrap();
+
+        let (_, held1) = poller.next().await.unwrap().unwrap();
+        let (_, held2) = poller.next().await.unwrap().unwrap();
+        let held_id1 = held1.id();
+        let held_id2 = held2.id();
+        assert_eq!(&*held1, b"held_aaa");
+        assert_eq!(&*held2, b"held_bbb");
+
+        for i in 0..10 {
+            let msg = format!("iter_{}", i);
+            sender
+                .send_to(msg.clone().into_bytes(), receiver_addr)
+                .await
+                .0
+                .unwrap();
+
+            let (_, buf) = poller.next().await.unwrap().unwrap();
+
+            assert_ne!(buf.id(), held_id1);
+            assert_ne!(buf.id(), held_id2);
+            assert_eq!(&*buf, msg.as_bytes());
+
+            assert_eq!(&*held1, b"held_aaa");
+            assert_eq!(&*held2, b"held_bbb");
+        }
+
+        drop(held1);
+        drop(held2);
+        drop(poller);
+        canceller.cancel();
+        while stream.stream().next().await.is_some() {}
+        stream.try_into_ring().ok().unwrap().unregister().unwrap();
+    }
+}


### PR DESCRIPTION
If you have time for review and interested in the changes I can also split this PR into 4 separate ones, i kept it this way to better demonstrate the scope of changes. Otherwise would appreciate any comments on the implementation.

- [io_uring multishot recv](https://man7.org/linux/man-pages/man3/io_uring_prep_recv_multishot.3.html)
- [io_uring multishot recvmsg](https://man7.org/linux/man-pages/man3/io_uring_prep_recvmsg_multishot.3.html)
- [io_uring register buf_ring](https://man7.org/linux/man-pages/man3/io_uring_register_buf_ring.3.html)

## 1. feat: add multishot lifecycle support

Extends the lifecycle state machine to handle multishot operations.
Unlike single-shot operations that produce one completion per submission,
multishot operations yield multiple completions until explicitly terminated via the IORING_CQE_F_MORE flag.

Example: single-shot recv

```rust
let (result, buf) = socket.recv(buf).await;
//   ├─ submit()  → Lifecycle::Submitted, returns Op<Recv>
//   ├─ .await    → poll() sees Submitted, stores waker → Lifecycle::Waiting(waker)
//   │              returns Poll::Pending, task suspends
//   │
//   │  kernel receives packet, posts CQE
//   │
//   ├─ complete()→ Lifecycle::Completed(result, flags), waker.wake()
//   ├─ .await    → poll() sees Completed, removes from slab, returns Poll::Ready
//   └─ done
```

Example: multishot recv

```rust
let ring = UserRingBuf::new(4, 1500, 0)?;              // 4 buffers, 1500 bytes each
let mut stream = socket.recv_multishot(ring)?;         // Lifecycle::Multishot { queue: [], terminated: false }
                                                       //   ↳ submits RecvMulti SQE to io_uring

sender.send_to(b"hello", addr).await;                  // kernel receives, posts CQE with MORE=1
                                                       //   ↳ complete(): queue.push(cqe), waker.wake()

let buf = stream.next().await;                         // poll_multishot(): queue.pop() → Ready(cqe)
assert_eq!(&*buf, b"hello");                           //   ↳ buf holds buffer #0
drop(buf);                                             //   ↳ buffer #0 returned to ring


sender.send_to(b"world", addr).await;                  // kernel posts CQE with MORE=1
let buf = stream.next().await;                         // poll_multishot() → Ready(cqe)
assert_eq!(&*buf, b"world");
drop(buf);

drop(stream);                                          // user drops while kernel still working
                                                       //   ↳ drop_op(): Lifecycle → Ignored(boxed_data)
                                                       //   ↳ slab entry kept alive
                                                       // once kernel finishes and posts cqe
                                                       //   ↳ complete(): if MORE=0, self.remove()
                                                       //   ↳ slab entry finally removed
```

## 2. feat: add ringbuf implementation

Implements io_uring provided [buffer rings](https://man7.org/linux/man-pages/man3/io_uring_register_buf_ring.3.html). The kernel picks buffers directly from a shared ring.

Buffer State Example:

Ring entries (slots) and buffer memory are decoupled. When returning a buffer, we write its address to slot[tail & 3] (next available slot), not its "original" slot.

```rust
let ring = UserRingBuf::new(4, 1500, 0)?;
let mut stream = socket.recv_multishot(ring)?;
// INITIAL     tail=4
//             ring slots:  [slot0→buf0, slot1→buf1, slot2→buf2, slot3→buf3]
//             user holds:  (none)

sender.send_to(b"aaa", addr).await;
let a = stream.next().await?;                          // kernel picks slot0→buf0, gives to user
// STEP 1      tail=4
//             ring slots:  [slot0:empty, slot1→buf1, slot2→buf2, slot3→buf3]
//             user holds:  a=buf0

sender.send_to(b"bbb", addr).await;
let b = stream.next().await?;                          // kernel picks slot1→buf1, gives to user
// STEP 2      tail=4
//             ring slots:  [slot0:empty, slot1:empty, slot2→buf2, slot3→buf3]
//             user holds:  a=buf0, b=buf1

sender.send_to(b"ccc", addr).await;
let c = stream.next().await?;                          // kernel picks slot2→buf2
drop(c);                                               // return_buffer(buf2):
                                                       //   slot[4 & 3] = slot0 → buf2, tail=5
// STEP 3      tail=5
//             ring slots:  [slot0→buf2, slot1:empty, slot2:empty, slot3→buf3]
//                          ↑ buf2 now in slot0 (was slot2)
//             user holds:  a=buf0, b=buf1

sender.send_to(b"ddd", addr).await;
let d = stream.next().await?;                          // kernel picks slot3→buf3
drop(d);                                               // return_buffer(buf3):
                                                       //   slot[5 & 3] = slot1 → buf3, tail=6
// STEP 4      tail=6
//             ring slots:  [slot0→buf2, slot1→buf3, slot2:empty, slot3:empty]
//                                       ↑ buf3 now in slot1 (was slot3)
//             user holds:  a=buf0, b=buf1
//
//             kernel cycles buf2↔buf3 via slots 0,1
//             buf0,buf1 memory untouched - not in any slot

drop(b);                                               // slot[6 & 3] = slot2 → buf1, tail=7
drop(a);                                               // slot[7 & 3] = slot3 → buf0, tail=8
// FINAL       tail=8
//             ring slots:  [slot0→buf2, slot1→buf3, slot2→buf1, slot3→buf0]
//             user holds:  (none)
```

For UserRecvMsgRingBuf, each buffer holds header + address + payload. Parser type parameter determines sockaddr size at compile time.

```bash
┌────────────────┬─────────────────────┬──────────────────────┐
│ RecvMsgOut Hdr │ sockaddr_in[6]      │ Payload              │
│ (16 bytes)     │ (16-28 bytes)       │ (variable)           │
├────────────────┴─────────────────────┼──────────────────────┤
│         parsed by parse_recvmsg()    │ returned as RawBuffer│
└──────────────────────────────────────┴──────────────────────┘
```

## 3. feat: add multishot op

Generic `MultishotOp<T>` wrapper for io_uring multishot operations.

io_uring multishot operations:

- recv multishot - with provided buffers (implemented)
- recvmsg multishot - with provided buffers (implemented)
- accept multishot - IORING_ACCEPT_MULTISHOT
- poll multishot - IORING_POLL_ADD_MULTI
- timeout multishot - IORING_TIMEOUT_MULTISHOT
- read multishot - IORING_OP_READ_MULTISHOT

To add new multishot ops: implement OpAble with uring_op() returning the multishot SQE, wrap in `MultishotOp<T>`.

## 4. feat: add recv/recvmsg multishot with tests

Uses [recv_multishot](https://man7.org/linux/man-pages/man3/io_uring_prep_recv_multishot.3.html)
and [recvmsg_multishot](https://man7.org/linux/man-pages/man3/io_uring_prep_recvmsg_multishot.3.html).

```rust
pub struct RecvMultishot<R: RingBuf> {
    ring: R,                                           // owns the buffer ring
    op: MultishotOp<RecvMultishotOp>,                  // owns the io_uring operation
    cancellation_guard: Option<AssociateGuard>,
}

pub struct RecvMultishotStream<'a, R: RingBuf> {
    ring: &'a R,                                       // borrows ring
    op: &'a mut MultishotOp<RecvMultishotOp>,          // borrows op mutably
    cancellation_guard: &'a Option<AssociateGuard>,
}
```

This separation enforces a single mutable poller (stream holds `&mut op`),
while allowing multiple buffers to be held simultaneously without borrow conflicts (buffers only need `&ring`).

```rust
let mut multishot = socket.recv_multishot(ring)?;
let mut stream = multishot.stream();

let buf1 = stream.next().await?;                       // Buffer<'a>
let buf2 = stream.next().await?;                       // Buffer<'a>, buf1 still valid
let buf3 = stream.next().await?;                       // all three coexist
process(&buf1, &buf2, &buf3);
drop(buf3);
drop(buf2);
drop(buf1);                                            // returned to ring in any order
```

Ring is reclaimable only after the multishot operation is fully terminated:

1. Kernel posts final CQE with IORING_CQE_F_MORE=0 (no more completions coming)
2. User drains all queued completions until stream.next() returns None

Termination happens naturally on error (e.g. ENOBUFS) or can be triggered via cancellation:

```rust
canceller.cancel();                                    // sends AsyncCancel SQE to io_uring
                                                       // kernel posts final CQE with MORE=0

while stream.next().await.is_some() {}                 // drain queue until None
                                                       // None means: terminated AND queue empty
drop(stream);                                          // release borrow

let ring = multishot.try_into_ring()?;                 // Ok only if terminated, Err(self) otherwise
ring.unregister()?;                                    // safe now: no in-flight buffers
```