### PR TITLE
feat: implement readable and writable  for Tcp Split

### DIFF
--- a/monoio/src/net/tcp/split.rs
+++ b/monoio/src/net/tcp/split.rs
@@ -23,6 +23,21 @@ impl TcpOwnedReadHalf {
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         unsafe { &*self.0.get() }.local_addr()
     }
+
+    /// Wait for read readiness.
+    /// Note: Do not use it before every io. It is different from other runtimes!
+    ///
+    /// Everytime call to this method may pay a syscall cost.
+    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use use
+    /// inner readiness state; if !relaxed, it will call syscall poll after that.
+    ///
+    /// If relaxed, on legacy driver it may return false positive result.
+    /// If you want to do io by your own, you must maintain io readiness and wait
+    /// for io ready with relaxed=false.
+    #[inline]
+    pub async fn readable(&self, relaxed: bool) -> Result<(), io::Error> {
+        unsafe { &*self.0.get() }.readable(relaxed).await
+    }
 }
 
 impl AsReadFd for TcpOwnedReadHalf {
@@ -44,6 +59,21 @@ impl TcpOwnedWriteHalf {
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         unsafe { &*self.0.get() }.local_addr()
+    }
+
+    /// Wait for write readiness.
+    /// Note: Do not use it before every io. It is different from other runtimes!
+    ///
+    /// Everytime call to this method may pay a syscall cost.
+    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use use
+    /// inner readiness state; if !relaxed, it will call syscall poll after that.
+    ///
+    /// If relaxed, on legacy driver it may return false positive result.
+    /// If you want to do io by your own, you must maintain io readiness and wait
+    /// for io ready with relaxed=false.
+    #[inline]
+    pub async fn writable(&self, relaxed: bool) -> Result<(), io::Error> {
+        unsafe { &*self.0.get() }.writable(relaxed).await
     }
 }
 

--- a/monoio/src/net/tcp/split.rs
+++ b/monoio/src/net/tcp/split.rs
@@ -27,15 +27,15 @@ impl TcpOwnedReadHalf {
     /// Wait for read readiness.
     /// Note: Do not use it before every io. It is different from other runtimes!
     ///
-    /// Everytime call to this method may pay a syscall cost.
-    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use use
+    /// Every call to this method may pay a syscall cost.
+    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use
     /// inner readiness state; if !relaxed, it will call syscall poll after that.
     ///
     /// If relaxed, on legacy driver it may return false positive result.
     /// If you want to do io by your own, you must maintain io readiness and wait
     /// for io ready with relaxed=false.
     #[inline]
-    pub async fn readable(&self, relaxed: bool) -> Result<(), io::Error> {
+    pub async fn readable(&self, relaxed: bool) -> io::Result<()> {
         unsafe { &*self.0.get() }.readable(relaxed).await
     }
 }
@@ -64,15 +64,15 @@ impl TcpOwnedWriteHalf {
     /// Wait for write readiness.
     /// Note: Do not use it before every io. It is different from other runtimes!
     ///
-    /// Everytime call to this method may pay a syscall cost.
-    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use use
+    /// Every call to this method may pay a syscall cost.
+    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use
     /// inner readiness state; if !relaxed, it will call syscall poll after that.
     ///
     /// If relaxed, on legacy driver it may return false positive result.
     /// If you want to do io by your own, you must maintain io readiness and wait
     /// for io ready with relaxed=false.
     #[inline]
-    pub async fn writable(&self, relaxed: bool) -> Result<(), io::Error> {
+    pub async fn writable(&self, relaxed: bool) -> io::Result<()> {
         unsafe { &*self.0.get() }.writable(relaxed).await
     }
 }

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -233,8 +233,8 @@ impl TcpStream {
     /// Wait for read readiness.
     /// Note: Do not use it before every io. It is different from other runtimes!
     ///
-    /// Everytime call to this method may pay a syscall cost.
-    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use use
+    /// Every call to this method may pay a syscall cost.
+    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use
     /// inner readiness state; if !relaxed, it will call syscall poll after that.
     ///
     /// If relaxed, on legacy driver it may return false positive result.
@@ -248,8 +248,8 @@ impl TcpStream {
     /// Wait for write readiness.
     /// Note: Do not use it before every io. It is different from other runtimes!
     ///
-    /// Everytime call to this method may pay a syscall cost.
-    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use use
+    /// Every call to this method may pay a syscall cost.
+    /// In uring impl, it will push a PollAdd op; in epoll impl, it will use
     /// inner readiness state; if !relaxed, it will call syscall poll after that.
     ///
     /// If relaxed, on legacy driver it may return false positive result.

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -112,7 +112,10 @@ async fn split_rw_able() {
             panic!("unexpected readable");
         }
     }
-    let (_, mut writer) = TcpStream::connect(listener_addr).await.unwrap().into_split();
+    let (_, mut writer) = TcpStream::connect(listener_addr)
+        .await
+        .unwrap()
+        .into_split();
 
     assert!(writer.writable(false).await.is_ok());
     assert!(listener.readable(false).await.is_ok());

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -100,6 +100,40 @@ async fn rw_able() {
     assert!(conn.readable(false).await.is_ok());
 }
 
+//essentially the same as rw_able, but test split stream instead of original stream
+#[monoio::test_all(timer_enabled = true)]
+async fn split_rw_able() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+
+    monoio::select! {
+        _ = monoio::time::sleep(std::time::Duration::from_millis(50)) => {},
+        _ = listener.readable(false) => {
+            panic!("unexpected readable");
+        }
+    }
+    let (_, mut writer) = TcpStream::connect(listener_addr).await.unwrap().into_split();
+
+    assert!(writer.writable(false).await.is_ok());
+    assert!(listener.readable(false).await.is_ok());
+    let (conn, _) = listener.accept().await.unwrap();
+    let (reader, _) = conn.into_split();
+    monoio::select! {
+        _ = monoio::time::sleep(std::time::Duration::from_millis(50)) => {},
+        _ = reader.readable(false) => {
+            panic!("unexpected readable");
+        }
+        _ = listener.readable(false) => {
+            // even listener's inner readiness state is ready, we will check it again
+            panic!("unexpected readable");
+        }
+    }
+    assert!(writer.writable(false).await.is_ok());
+    let (res, _) = writer.write_all("MSG").await;
+    assert!(res.is_ok());
+    assert!(reader.readable(false).await.is_ok());
+}
+
 #[monoio::test_all]
 async fn echo_tfo() {
     use std::net::SocketAddr;


### PR DESCRIPTION
### Problem
`TcpOwnedReadHalf` and `TcpOwnedWriteHalf` currently do not support waiting for the stream to be readable or writable, as the split does not expose the underlying `readable` and `writable` functions.

### Design
We can safely expose both functions on the Read and Write split of the TcpStream since this does not require manipulation of a shared Fd and merely exposes already-implemented functions.

### Solution
Adds proxy functions to `TcpStream`'s `writable(relaxed)` and `readable(relaxed)` functions for `TcpOwnedWriteHalf` and `TcpOwnedReadHalf`.