### PR TITLE
feat: re-export io_uring::IoUring to avoid direct dependency for SQPO…

### DIFF
--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -43,7 +43,7 @@ pub use driver::Driver;
 pub use driver::IoUringDriver;
 #[cfg(feature = "legacy")]
 pub use driver::LegacyDriver;
-#[cfg(feature = "iouring")]
+#[cfg(all(target_os = "linux", feature = "iouring"))]
 pub use io_uring::IoUring;
 #[cfg(feature = "macros")]
 pub use monoio_macros::{main, test, test_all};

--- a/monoio/src/lib.rs
+++ b/monoio/src/lib.rs
@@ -43,6 +43,8 @@ pub use driver::Driver;
 pub use driver::IoUringDriver;
 #[cfg(feature = "legacy")]
 pub use driver::LegacyDriver;
+#[cfg(feature = "iouring")]
+pub use io_uring::IoUring;
 #[cfg(feature = "macros")]
 pub use monoio_macros::{main, test, test_all};
 pub use runtime::{spawn, Runtime};


### PR DESCRIPTION
Problem: configuring SQPOLL requires users to add io-uring as a 
direct dependency and manually match the version used internally 
by monoio, leading to potential type mismatches.

Solution: re-export io_uring::IoUring so users can configure 
advanced io_uring options without importing io-uring directly.

Before:
```
  // requires io-uring in Cargo.toml + version matching
  use io_uring::IoUring;
  let builder = IoUring::builder();

```
After:
```
  // just monoio
  use monoio::IoUring;
  let builder = monoio::IoUring::builder();
```