### PR TITLE
fix: hide false positive clippy error

### DIFF
--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -522,6 +522,7 @@ impl Drop for Inner {
         let fd = self.fd;
         let state = unsafe { &mut *self.state.get() };
         #[allow(unreachable_patterns)]
+        #[allow(clippy::collapsible_match)] // false positive: the `if` is a match guard, not collapsible
         match state {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
             State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..)) => {

--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -522,7 +522,8 @@ impl Drop for Inner {
         let fd = self.fd;
         let state = unsafe { &mut *self.state.get() };
         #[allow(unreachable_patterns)]
-        #[allow(clippy::collapsible_match)] // false positive: the `if` is a match guard, not collapsible
+        #[allow(clippy::collapsible_match)]
+        // false positive: the `if` is a match guard, not collapsible
         match state {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
             State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..))

--- a/monoio/src/utils/slab.rs
+++ b/monoio/src/utils/slab.rs
@@ -47,6 +47,7 @@ impl<T> Slab<T> {
         let page_id = get_page_id(key);
         // here we make 2 mut ref so we must make it safe.
         let slab = unsafe { &mut *(self as *mut Slab<T>) };
+        #[allow(clippy::question_mark)]
         let page = match unsafe { self.pages.get_unchecked_mut(page_id) } {
             Some(page) => page,
             None => return None,
@@ -93,6 +94,7 @@ impl<T> Slab<T> {
     #[allow(unused)]
     pub(crate) fn remove(&mut self, key: usize) -> Option<T> {
         let page_id = get_page_id(key);
+        #[allow(clippy::question_mark)]
         let page = match unsafe { self.pages.get_unchecked_mut(page_id) } {
             Some(page) => page,
             None => return None,


### PR DESCRIPTION
### Problem
Clippy detects an `if` statement as an if statement inside a match arm when in reality it is part of the match pattern.

### Solution
Hide clippy's `collapsible match` warning for the specific match statement, with a comment explaining the false positive.