### PR TITLE
chore(deps): replace dependency auto-const-array with auto_array

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.2.4"
 [dependencies]
 monoio-macros = { version = "0.1.0", path = "../monoio-macros", optional = true }
 
-auto-const-array = "0.2"
+auto_array = "0.1.1"
 rustc-hash = "2.0"
 libc = "0.2"
 pin-project-lite = "0.2"

--- a/monoio/src/utils/uring_detect.rs
+++ b/monoio/src/utils/uring_detect.rs
@@ -22,7 +22,7 @@ fn detect_uring_inner() -> bool {
     }
 
     use io_uring::opcode::*;
-    auto_const_array::auto_const_array! {
+    auto_array::auto_array!(
         const USED_OP: [u8; _] = [
             Accept::CODE,
             AsyncCancel::CODE,
@@ -53,7 +53,7 @@ fn detect_uring_inner() -> bool {
             Write::CODE,
             Writev::CODE,
         ];
-    }
+    );
 
     let uring = err_to_false!(io_uring::IoUring::new(2));
     let mut probe = io_uring::Probe::new();


### PR DESCRIPTION
Functionally both crates do the same thing, but the replacement uses a very simple declarative macro instead of a procedural macro.
As a result it doesn't need to depend on `proc-macro2`, `quote`, and `syn`, and should be faster to compile.