### PR TITLE
fix: enable Windows console APIs for signal support

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -42,6 +42,7 @@ once_cell = { version = "1.19.0", optional = true }
 windows-sys = { version = "0.48.0", features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
+    "Win32_System_Console",
     "Win32_System_IO",
     "Win32_Storage_FileSystem",
     "Win32_Security",


### PR DESCRIPTION
## Problem

The `signal` feature compiles `monoio/src/utils/ctrlc.rs` on Windows, where it calls `GenerateConsoleCtrlEvent` and uses `CTRL_C_EVENT`. Those items are gated behind the `Win32_System_Console` feature in `windows-sys`, but Monoio's target-specific dependency did not enable it.

## Change

Enable `Win32_System_Console` alongside the existing `windows-sys` features. This uses the existing dependency and does not change Monoio's public API.

Fixes #403.

## Validation

- `cargo check -p monoio --no-default-features --features signal,legacy`
- `cargo test -p monoio --no-default-features --features signal,legacy,macros --test ctrlc_legacy --no-run`
- `cargo check --workspace --all-targets`